### PR TITLE
feat(wiki): add global footer for wiki pages

### DIFF
--- a/_Footer.md
+++ b/_Footer.md
@@ -1,0 +1,8 @@
+---
+
+<p align="center">
+  <a href="Home">Home</a> · <a href="Onboarding">Onboarding</a> · <a href="Code-Style">Code Style</a> · <a href="Life-Cycle">Life Cycle</a> · <a href="Cookbooks">Cookbooks</a>
+</p>
+<p align="center">
+  <a href="https://github.com/rios0rios0/guide/blob/main/CONTRIBUTING.md">Contributing</a> · <a href="https://github.com/rios0rios0/guide/blob/main/LICENSE">MIT License</a> · <a href="https://github.com/rios0rios0/guide">GitHub Repository</a>
+</p>


### PR DESCRIPTION
## Summary

- Add `_Footer.md` to provide a consistent footer across all GitHub Wiki pages
- Top row: quick navigation links to the main sections (Home, Onboarding, Code Style, Life Cycle, Cookbooks)
- Bottom row: links to Contributing guidelines, MIT License, and the GitHub repository
- Centered layout with a horizontal rule separator

## Test plan

- [ ] Verify the footer renders correctly on the GitHub Wiki after the wiki sync workflow runs
- [ ] Confirm navigation links resolve to the correct wiki pages
- [ ] Confirm external links (Contributing, License, Repository) point to the correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 70e1b9570fe8c1b382e8d207ce15d1d73a045543. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->