### PR TITLE
feat(ai-rules): added AI rule files for Claude Code, Cursor, and OpenAI Codex

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -20,6 +20,9 @@ And its objective is not to limit the development to a specific form, but to pro
   - [Documentation & Change Control](Life-Cycle/Documentation-&-Change-Control.md)
     - [README Template](Life-Cycle/Documentation-&-Change-Control/README-Template.md)
     - [CONTRIBUTING Template](Life-Cycle/Documentation-&-Change-Control/CONTRIBUTING-Template.md)
+    - [CLAUDE.md Template](Life-Cycle/Documentation-&-Change-Control/CLAUDE-Template.md)
+    - [Cursorrules Template](Life-Cycle/Documentation-&-Change-Control/Cursorrules-Template.md)
+    - [AGENTS.md Template](Life-Cycle/Documentation-&-Change-Control/AGENTS-Template.md)
 - [Code Style](Code-Style.md)
   - [Language Guide Template](Code-Style/Language-Guide-Template.md)
   - [GoLang](Code-Style/GoLang.md)
@@ -54,6 +57,7 @@ And its objective is not to limit the development to a specific form, but to pro
     - [Database Sync](Cookbooks/Tools-&-Setup/Database-Sync.md)
   - [Forking Technique](Cookbooks/Forking-Technique.md)
   - [Historical Repository Cleaner](Cookbooks/Historical-Repository-Cleaner.md)
+  - [Mapper Design Pattern](Cookbooks/Mapper-Design-Pattern.md)
 
 ## References
 - [Vizir's StyleGuide](https://github.com/Vizir/styleguide)

--- a/Life-Cycle/Documentation-&-Change-Control.md
+++ b/Life-Cycle/Documentation-&-Change-Control.md
@@ -18,11 +18,17 @@ Every project must contain at minimum:
 | **`CONTRIBUTING.md`**                 | Guides contributors on prerequisites, workflow, and standards | When prerequisites, workflow, or project structure changes    |
 | **`CHANGELOG.md`**                    | Records all notable changes, organized by version            | **Every change** (always)                                    |
 | **`.github/copilot-instructions.md`** | AI assistant context for the project structure and workflows | When architecture, commands, or development workflow changes |
+| **`CLAUDE.md`**                       | Claude Code project rules and conventions                    | When architecture, commands, or development workflow changes |
+| **`.cursorrules`**                    | Cursor project rules and conventions                         | When architecture, commands, or development workflow changes |
+| **`AGENTS.md`**                       | OpenAI Codex project rules and conventions                   | When architecture, commands, or development workflow changes |
 
 **Templates are available for standardized project setup:**
 
 - [README Template](Documentation-&-Change-Control/README-Template.md) -- copy and customize for new projects
 - [CONTRIBUTING Template](Documentation-&-Change-Control/CONTRIBUTING-Template.md) -- copy and customize for new projects
+- [CLAUDE.md Template](Documentation-&-Change-Control/CLAUDE-Template.md) -- Claude Code rules for new projects
+- [Cursorrules Template](Documentation-&-Change-Control/Cursorrules-Template.md) -- Cursor rules for new projects
+- [AGENTS.md Template](Documentation-&-Change-Control/AGENTS-Template.md) -- OpenAI Codex rules for new projects
 
 ## Changelog Standard
 
@@ -107,15 +113,52 @@ The `README.md` must accurately describe the current state of the project. Updat
 
 ## AI Assistant Instructions
 
-Projects that use AI-assisted development (GitHub Copilot, Cursor, etc.) should maintain a `.github/copilot-instructions.md` file. This file provides the AI with project-specific context about:
+Projects that use AI-assisted development must maintain instruction files for each AI tool in use. These files provide AI assistants with project-specific context and enforce the team's development standards automatically.
+
+### Supported AI Tools
+
+| Tool           | File                              | Purpose                                                           |
+|----------------|-----------------------------------|-------------------------------------------------------------------|
+| GitHub Copilot | `.github/copilot-instructions.md` | Copilot context for project structure and workflows               |
+| Claude Code    | `CLAUDE.md`                       | Claude Code rules for architecture, testing, and code conventions |
+| Cursor         | `.cursorrules`                    | Cursor rules for architecture, testing, and code conventions      |
+| OpenAI Codex   | `AGENTS.md`                       | Codex rules for architecture, testing, and code conventions       |
+
+### What to Include
+
+All AI instruction files should provide context about:
 
 - Project purpose and architecture
-- Build, test, and lint commands with expected timings
+- Build, test, and lint commands
 - Repository structure and key files
 - Development workflow and validation steps
 - Testing infrastructure and conventions
+- Commit message format and branch naming
+- YAML conventions and security requirements
 
-Update this file whenever the development workflow, architecture, or key commands change.
+### Installation
+
+Use the `install-ai-rules.sh` script from the [guide repository](https://github.com/rios0rios0/guide) to install all AI rule files into a project:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rios0rios0/guide/main/install-ai-rules.sh | bash -s -- .
+```
+
+Or clone the guide and run locally:
+
+```bash
+./install-ai-rules.sh /path/to/your/project
+```
+
+The script generates `CLAUDE.md`, `.cursorrules`, and `AGENTS.md` with the team's full conventions embedded. It overwrites existing files with the same name. No configuration needed -- the AI agents will immediately know all architecture, testing, code style, security, and documentation conventions.
+
+### Templates
+
+- [CLAUDE.md Template](Documentation-&-Change-Control/CLAUDE-Template.md)
+- [Cursorrules Template](Documentation-&-Change-Control/Cursorrules-Template.md)
+- [AGENTS.md Template](Documentation-&-Change-Control/AGENTS-Template.md)
+
+Update these files whenever the development workflow, architecture, or key commands change.
 
 ## Workflow Integration
 
@@ -124,7 +167,7 @@ Documentation updates must be part of the same commit or PR that introduces the 
 1. **Write the code change.**
 2. **Update `CHANGELOG.md`** -- add an entry under `[Unreleased]` describing what changed.
 3. **Update `README.md`** -- if the change affects usage, setup, or architecture.
-4. **Update `.github/copilot-instructions.md`** -- if the change affects build commands, project structure, or development workflow.
+4. **Update AI instruction files** (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `.github/copilot-instructions.md`) -- if the change affects build commands, project structure, or development workflow.
 5. **Commit everything together.** Documentation and code ship as one unit.
 
 **Never merge a PR that introduces user-facing or architectural changes without the corresponding documentation update.**

--- a/Life-Cycle/Documentation-&-Change-Control/AGENTS-Template.md
+++ b/Life-Cycle/Documentation-&-Change-Control/AGENTS-Template.md
@@ -1,0 +1,307 @@
+# AGENTS.md Template
+
+> **TL;DR:** Copy the template below into an `AGENTS.md` file at the project root. This file gives [OpenAI Codex](https://github.com/openai/codex) the full team development standards so it can write code, review PRs, and enforce conventions automatically -- no manual intervention needed.
+
+## Overview
+
+OpenAI Codex reads `AGENTS.md` from the project root (and parent directories) to understand project conventions. This template embeds the entire [Development Guide](https://github.com/rios0rios0/guide/wiki) so that Codex already knows every convention, architecture pattern, and language-specific rule the team follows. Install it via `install-ai-rules.sh` or copy the content below.
+
+## Template
+
+````markdown
+# AGENTS.md
+
+## Commands
+
+```bash
+make lint    # fix all linter issues
+make test    # run the full test suite
+make sast    # run the complete SAST security suite
+```
+
+Always run lint, test, and sast before considering any task complete.
+
+## Architecture
+
+Follow **Hexagonal Architecture (Ports & Adapters)** with **Domain-Driven Design (DDD)** and **CQRS**.
+
+### Layer Separation
+
+- `domain/` contains contracts: entities, repository interfaces, service interfaces, and commands.
+- `infrastructure/` contains implementations: controllers, repository implementations, service implementations, and mappers.
+- Dependencies always point inward -- infrastructure depends on domain, never the reverse.
+- Entities must be **framework-agnostic**. No ORM annotations, no framework tags, no external dependencies inside entity definitions.
+
+### Principal Actors
+
+| Actor            | Responsibility                                                                                                    |
+|------------------|-------------------------------------------------------------------------------------------------------------------|
+| **Entities**     | Core business objects. Contain domain rules about what the modeled objects are and how they behave. Framework-agnostic. |
+| **Controllers**  | Bridge between the view (client) and the business layer. Receive requests and delegate to commands.               |
+| **Commands**     | Implement business/feature logic and apply domain rules. Define a `Listeners` record for callback outcomes.       |
+| **Services**     | Handle application-level concerns: parsing, conversions, transformations. Domain layer defines the contract (interface), infrastructure provides the implementation. |
+| **Repositories** | Abstract all data access. Changing the database technology requires modifying only the repository implementation. |
+
+### Mappers
+
+Use mappers to isolate layers. Never let framework types leak across layer boundaries:
+- **Repository mappers:** convert between infrastructure models (prefixed with tool name, e.g., `PgxUser`, `JpaItem`) and domain entities.
+- **Controller mappers:** convert between request/response DTOs and domain entities. Separate request mappers from response mappers.
+
+### File Structure Tiers
+
+Scale structure with complexity:
+
+**Minimal (3 layers):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+infrastructure/repositories/
+```
+
+**Intermediate (with Services):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+domain/services/
+infrastructure/repositories/
+infrastructure/services/
+```
+
+**Complete (with API layer):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+domain/services/
+infrastructure/controllers/
+infrastructure/controllers/requests/
+infrastructure/controllers/responses/
+infrastructure/controllers/mappers/
+infrastructure/repositories/
+infrastructure/repositories/mappers/
+infrastructure/repositories/models/
+infrastructure/services/
+infrastructure/services/mappers/
+```
+
+### Frontend Architecture
+
+5-layer lightweight Clean Architecture:
+- **Domain** -- most abstract layer, defines entities and contracts.
+- **Service** -- communication with APIs and external services.
+- **Infrastructure** -- technology-specific implementations.
+- **Presentation** -- view-rendering code (components, pages, hooks).
+- **Main** -- wiring layer, instantiates providers and services, handles DI.
+
+Dependencies always point toward Domain.
+
+## Operations Vocabulary
+
+Use these standard prefixes consistently for naming files, classes, and methods:
+
+| Operation     | Description               |
+|---------------|---------------------------|
+| `List`        | Retrieve multiple records |
+| `Get`         | Retrieve a single record  |
+| `Insert`      | Create a single record    |
+| `Update`      | Modify a single record    |
+| `Delete`      | Remove a single record    |
+| `BatchInsert` | Create multiple records   |
+| `BatchUpdate` | Modify multiple records   |
+| `BatchDelete` | Remove multiple records   |
+| `DeleteAll`   | Remove all records        |
+
+## Git Conventions
+
+### Commit Messages
+
+Format: `type(SCOPE): message`
+
+- **SCOPE** is the task ID (e.g., `TICKET-123`) or a short descriptive scope.
+- Use **simple past tense**: `added`, `changed`, `fixed`, `removed`.
+- **No period** at the end. **Do not capitalize** the first letter.
+- Wrap code references in backticks.
+
+Types: `feat`, `fix`, `refactor`, `chore`, `test`, `docs`.
+
+Long commit messages use a body with bullet points starting with a lowercase verb in past tense.
+
+### Branches
+
+Format: `type/TICKET-ID` or `type/short-description` (e.g., `feat/TICKET-000`, `fix/input-mask`).
+
+### Branch Synchronization
+
+Always use `git rebase` to synchronize with `main`. Never merge `main` into feature branches.
+
+### Breaking Changes
+
+Flag in three places:
+1. Commit footer: `**BREAKING CHANGE:** description`
+2. `CHANGELOG.md` entry: `- **BREAKING CHANGE:** description`
+3. PR description: `**BREAKING CHANGE:** description`
+
+### Semantic Versioning
+
+- **MAJOR** (`X.0.0`): breaking changes, new native modules, drastic structural changes.
+- **MINOR** (`0.X.0`): incremental features, no breaking changes.
+- **PATCH** (`0.0.X`): bug fixes in production only.
+
+## Testing
+
+### BDD Pattern (mandatory)
+
+All tests must use clearly separated comment blocks:
+
+| Language                | Given      | When      | Then      |
+|-------------------------|------------|-----------|-----------||
+| Go                      | `// given` | `// when` | `// then` |
+| JavaScript / TypeScript | `// given` | `// when` | `// then` |
+| Java                    | `// given` | `// when` | `// then` |
+| Python                  | `# given`  | `# when`  | `# then`  |
+
+### Test Descriptions
+
+- Commands: `"should call <LISTENER> when ..."`
+- Controllers: `"should respond <HTTP_STATUS_CODE> (<HTTP_STATUS>) when ..."`
+- Services/Repositories: `"should ... when ..."` -- at least one success and one failure test per public method.
+
+### Test Doubles (preference order)
+
+1. **Stubs** -- return pre-configured (canned) answers. No in-memory logic.
+2. **Dummies** -- fill required parameters that are never used. Return minimal values.
+3. **In-memory** -- implement logic in memory without external modules.
+4. **Fakers** -- generate realistic fake data via an external library.
+5. **Mocks** -- record and verify method calls. **Avoid when possible.**
+
+### Builders
+
+Use the Builder Design Pattern for constructing complex test objects:
+```
+UserBuilder.new().withName("John Doe").withEmail("john@example.com").build()
+```
+
+## Documentation
+
+Every code change must include corresponding documentation updates:
+
+1. **`CHANGELOG.md`** -- always. Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Add entries under `[Unreleased]` with categories: Added, Changed, Deprecated, Removed, Fixed, Security. Start each entry with a lowercase verb in simple past tense. Be specific.
+2. **`README.md`** -- when behavior, configuration, CLI, or setup changes.
+3. **`CONTRIBUTING.md`** -- when prerequisites, workflow, or project structure changes.
+4. **AI instruction files** (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `.github/copilot-instructions.md`) -- when architecture, commands, or development workflow changes.
+
+Documentation and code ship as one unit in the same commit. Never merge a PR that introduces user-facing or architectural changes without the corresponding documentation update.
+
+## YAML Conventions
+
+- Always use `.yaml` extension (never `.yml`). Exception only when the tool enforces `.yml` (e.g., Azure DevOps `azure-pipelines.yml`).
+- Always single-quote strings: `name: 'my-service'`.
+- Double quotes only for interpolation or escape sequences: `url: "${API_HOST}/v1"`, `message: "line1\nline2"`.
+- Never quote booleans or numbers: `enabled: true`, `replicas: 3`.
+- These rules apply to all YAML: CI/CD pipelines, Kubernetes manifests, Docker Compose, Helm values, application configs, and YAML code blocks inside Markdown.
+
+## Security
+
+- Never hard-code secrets, API keys, tokens, or passwords. Use environment variables or secret managers (1Password, Vault, AWS Secrets Manager).
+- Follow OWASP Top 10 guidelines: validate and sanitize all user input, use parameterized queries, enforce MFA, implement RBAC, use HTTPS/TLS, encrypt data at rest.
+- Run `make sast` before every push. The SAST suite includes CodeQL, Semgrep, Trivy, Hadolint, and Gitleaks.
+- If Gitleaks detects a leaked secret, rotate the credential immediately.
+- Use `.env` files for local development but never commit them.
+
+## Language-Specific Conventions
+
+### Go
+
+- **File names:** `snake_case` (e.g., `list_users_command.go`).
+- **Method receivers:** one or two letter abbreviation of the type (`c` for `Command`, `r` for `Repository`). Never use `self`, `this`, or `me`.
+- **Entities:** framework-agnostic. No `json`, `gorm`, or other tags inside entity structs.
+- **DI:** use [Uber Dig](https://github.com/uber-go/dig). Each architectural layer has a `container.go` file for provider registration.
+- **Naming patterns:**
+  - Commands: `<operation>_<entity>_command.go` / `<Operation><Entity>Command` / method `Execute`.
+  - Controllers: `<operation>_<entity>_controller.go` / `<Operation><Entity>Controller` / method `Execute`.
+  - Repositories (contract): `<entity>_repository.go` / `<Entity>Repository` (interface).
+  - Repositories (impl): `<library>_<entity>_repository.go` / `<Library><Entity>Repository`.
+  - Mappers: `<entity>_mapper.go` / `<Entity>Mapper`.
+  - Models: prefixed with external tool name (e.g., `PgxUser`, `AwsFile`).
+- **Linting:** `golangci-lint`.
+- **Logging:** `Logrus`.
+- **Testing:** `testify` (assert + suite + mock).
+- **Services layer:** not used in Go projects.
+- **Repository methods:** `FindByField`, `FindAllByField`, `HasCondition`, `Save`, `SaveAll`, `DeleteByField`.
+- **Project structure:** `cmd/<app>/` (entry point + `dig.go`), `internal/domain/`, `internal/infrastructure/`, `test/` (builders, doubles, helpers).
+
+### JavaScript / TypeScript
+
+- **File names:** `snake_case` (e.g., `my_class.js`).
+- **HTML attributes:** `camelCase` for `id` and `data-test-subj` values.
+- **Formatting:** Prettier. **Linting:** ESLint.
+- Prefer arrow functions, template strings, spread operator, optional chaining (`?.`), nullish coalescing (`??`).
+- **Never use `any`** -- use `unknown` with type narrowing instead.
+- **Immutability:** do not reassign variables, modify object properties, or push to arrays. Create new copies.
+- **Destructuring:** use object and array destructuring instead of index access.
+
+### Java
+
+- **File names:** `PascalCase` (matches class name, e.g., `ListItemsCommand.java`).
+- **Framework:** Spring Boot.
+- **DI:** constructor injection via Lombok `@RequiredArgsConstructor`. **Never** use field injection (`@Autowired` on fields). Mark injected fields as `final`.
+- **Annotations:** `@Component` for commands/listeners, `@RestController` for controllers, `@Repository` for repositories, `@Service` for services.
+- **Mapping:** MapStruct with `@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)` and `INSTANCE` pattern.
+- **Entities:** no `@Entity`, `@Table`, `@Column`, or JPA annotations. Use Java records for DTOs and value objects.
+- **Models:** prefixed with `Jpa` (e.g., `JpaItem`). Annotated with `@Entity`, `@Getter`, `@Setter`, `@SuperBuilder`, `@NoArgsConstructor`.
+- **Naming patterns:**
+  - Commands: `<Operation><Entity>Command.java` / method `execute` / inner `Listeners` record.
+  - Controllers: `<Operation><Entity>Controller.java` / method `execute`.
+  - Services (contract): `<Operation><Entity>Service.java` (interface).
+  - Services (impl): `Jpa<Operation><Entity>Service.java`.
+  - Repositories (contract): `<Entity>Repository.java` (interface).
+  - Repositories (impl): `Jpa<Entity>Repository.java` (extends `JpaRepository`).
+- **Formatting:** Google Java Format via Spotless. **Linting:** Checkstyle + PMD.
+- **Logging:** SLF4J with Logback.
+- **Testing:** JUnit 5 + Mockito.
+- **Build:** Gradle (always use `gradlew` wrapper).
+- **Database:** Liquibase with `.yaml` format, `snake_case` names, single quotes, rollback + pre-conditions on every changeset, constraints before column name.
+- **Principles:** program to interfaces, favor composition over inheritance, immutability by default (`final`), fail fast, convention over configuration.
+
+### Python
+
+- **File names:** `snake_case` (e.g., `list_users_command.py`). Package names cannot contain dashes.
+- **Classes:** `PascalCase`.
+- **Formatting:** Black. **Import sorting:** isort. **Linting:** Flake8.
+- **Type hints:** required on all function signatures.
+- **Logging:** Loguru.
+- **Testing:** pytest.
+- **Package manager:** PDM with PEP 621 metadata in `pyproject.toml`.
+- **Entities:** framework-agnostic, no ORM base classes or decorators.
+- **Naming patterns:**
+  - Commands: `<operation>_<entity>_command.py` / `<Operation><Entity>Command` / method `execute`.
+  - Controllers: `<operation>_<entity>_controller.py` / `<Operation><Entity>Controller` / method `execute`.
+  - Repositories (contract): `<entity>_repository.py` / `<Entity>Repository` (ABC with `@abstractmethod`).
+  - Repositories (impl): `<library>_<entity>_repository.py` / `<Library><Entity>Repository`.
+- **DI:** constructor injection. Use framework DI (e.g., FastAPI) or wire manually in composition root.
+- Use descriptive variable names. Write comments that explain **why**, not just **what**.
+
+## Code Review Guardrails
+
+When reviewing code, enforce these rules:
+
+1. **Architecture violations:** entities must not import from infrastructure. Dependencies must point inward.
+2. **Framework leakage:** no ORM annotations, framework tags, or external tool dependencies inside domain entities.
+3. **Naming consistency:** operations vocabulary (`List`, `Get`, `Insert`, `Update`, `Delete`) must be used. File and class naming must follow language-specific patterns.
+4. **Test quality:** every test must have `given`/`when`/`then` blocks. Prefer stubs over mocks. At least one success + one failure test per public method.
+5. **Documentation:** changelog entry is mandatory. README update is mandatory when behavior changes.
+6. **Commit format:** `type(SCOPE): message` in simple past tense.
+7. **Security:** no hardcoded secrets, parameterized queries, input validation present.
+8. **YAML:** `.yaml` extension, single-quoted strings, unquoted booleans/numbers.
+9. **Immutability:** `final` fields in Java, no mutation in JS/TS, constructor injection everywhere.
+10. **Layer isolation:** mappers exist between layers, no direct coupling between controllers and repositories.
+````
+
+## References
+
+- [Documentation & Change Control](../Documentation-&-Change-Control.md)
+- [OpenAI Codex](https://github.com/openai/codex)
+- [Development Guide Wiki](https://github.com/rios0rios0/guide/wiki)

--- a/Life-Cycle/Documentation-&-Change-Control/CLAUDE-Template.md
+++ b/Life-Cycle/Documentation-&-Change-Control/CLAUDE-Template.md
@@ -1,0 +1,307 @@
+# CLAUDE.md Template
+
+> **TL;DR:** Copy the template below into a `CLAUDE.md` file at the project root. This file gives [Claude Code](https://docs.anthropic.com/en/docs/claude-code) the full team development standards so it can write code, review PRs, and enforce conventions automatically -- no manual intervention needed.
+
+## Overview
+
+Claude Code reads `CLAUDE.md` from the project root (and parent directories) to understand project conventions. This template embeds the entire [Development Guide](https://github.com/rios0rios0/guide/wiki) so that Claude Code already knows every convention, architecture pattern, and language-specific rule the team follows. Install it via `install-ai-rules.sh` or copy the content below.
+
+## Template
+
+````markdown
+# CLAUDE.md
+
+## Commands
+
+```bash
+make lint    # fix all linter issues
+make test    # run the full test suite
+make sast    # run the complete SAST security suite
+```
+
+Always run lint, test, and sast before considering any task complete.
+
+## Architecture
+
+Follow **Hexagonal Architecture (Ports & Adapters)** with **Domain-Driven Design (DDD)** and **CQRS**.
+
+### Layer Separation
+
+- `domain/` contains contracts: entities, repository interfaces, service interfaces, and commands.
+- `infrastructure/` contains implementations: controllers, repository implementations, service implementations, and mappers.
+- Dependencies always point inward -- infrastructure depends on domain, never the reverse.
+- Entities must be **framework-agnostic**. No ORM annotations, no framework tags, no external dependencies inside entity definitions.
+
+### Principal Actors
+
+| Actor            | Responsibility                                                                                                    |
+|------------------|-------------------------------------------------------------------------------------------------------------------|
+| **Entities**     | Core business objects. Contain domain rules about what the modeled objects are and how they behave. Framework-agnostic. |
+| **Controllers**  | Bridge between the view (client) and the business layer. Receive requests and delegate to commands.               |
+| **Commands**     | Implement business/feature logic and apply domain rules. Define a `Listeners` record for callback outcomes.       |
+| **Services**     | Handle application-level concerns: parsing, conversions, transformations. Domain layer defines the contract (interface), infrastructure provides the implementation. |
+| **Repositories** | Abstract all data access. Changing the database technology requires modifying only the repository implementation. |
+
+### Mappers
+
+Use mappers to isolate layers. Never let framework types leak across layer boundaries:
+- **Repository mappers:** convert between infrastructure models (prefixed with tool name, e.g., `PgxUser`, `JpaItem`) and domain entities.
+- **Controller mappers:** convert between request/response DTOs and domain entities. Separate request mappers from response mappers.
+
+### File Structure Tiers
+
+Scale structure with complexity:
+
+**Minimal (3 layers):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+infrastructure/repositories/
+```
+
+**Intermediate (with Services):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+domain/services/
+infrastructure/repositories/
+infrastructure/services/
+```
+
+**Complete (with API layer):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+domain/services/
+infrastructure/controllers/
+infrastructure/controllers/requests/
+infrastructure/controllers/responses/
+infrastructure/controllers/mappers/
+infrastructure/repositories/
+infrastructure/repositories/mappers/
+infrastructure/repositories/models/
+infrastructure/services/
+infrastructure/services/mappers/
+```
+
+### Frontend Architecture
+
+5-layer lightweight Clean Architecture:
+- **Domain** -- most abstract layer, defines entities and contracts.
+- **Service** -- communication with APIs and external services.
+- **Infrastructure** -- technology-specific implementations.
+- **Presentation** -- view-rendering code (components, pages, hooks).
+- **Main** -- wiring layer, instantiates providers and services, handles DI.
+
+Dependencies always point toward Domain.
+
+## Operations Vocabulary
+
+Use these standard prefixes consistently for naming files, classes, and methods:
+
+| Operation     | Description               |
+|---------------|---------------------------|
+| `List`        | Retrieve multiple records |
+| `Get`         | Retrieve a single record  |
+| `Insert`      | Create a single record    |
+| `Update`      | Modify a single record    |
+| `Delete`      | Remove a single record    |
+| `BatchInsert` | Create multiple records   |
+| `BatchUpdate` | Modify multiple records   |
+| `BatchDelete` | Remove multiple records   |
+| `DeleteAll`   | Remove all records        |
+
+## Git Conventions
+
+### Commit Messages
+
+Format: `type(SCOPE): message`
+
+- **SCOPE** is the task ID (e.g., `TICKET-123`) or a short descriptive scope.
+- Use **simple past tense**: `added`, `changed`, `fixed`, `removed`.
+- **No period** at the end. **Do not capitalize** the first letter.
+- Wrap code references in backticks.
+
+Types: `feat`, `fix`, `refactor`, `chore`, `test`, `docs`.
+
+Long commit messages use a body with bullet points starting with a lowercase verb in past tense.
+
+### Branches
+
+Format: `type/TICKET-ID` or `type/short-description` (e.g., `feat/TICKET-000`, `fix/input-mask`).
+
+### Branch Synchronization
+
+Always use `git rebase` to synchronize with `main`. Never merge `main` into feature branches.
+
+### Breaking Changes
+
+Flag in three places:
+1. Commit footer: `**BREAKING CHANGE:** description`
+2. `CHANGELOG.md` entry: `- **BREAKING CHANGE:** description`
+3. PR description: `**BREAKING CHANGE:** description`
+
+### Semantic Versioning
+
+- **MAJOR** (`X.0.0`): breaking changes, new native modules, drastic structural changes.
+- **MINOR** (`0.X.0`): incremental features, no breaking changes.
+- **PATCH** (`0.0.X`): bug fixes in production only.
+
+## Testing
+
+### BDD Pattern (mandatory)
+
+All tests must use clearly separated comment blocks:
+
+| Language                | Given      | When      | Then      |
+|-------------------------|------------|-----------|-----------||
+| Go                      | `// given` | `// when` | `// then` |
+| JavaScript / TypeScript | `// given` | `// when` | `// then` |
+| Java                    | `// given` | `// when` | `// then` |
+| Python                  | `# given`  | `# when`  | `# then`  |
+
+### Test Descriptions
+
+- Commands: `"should call <LISTENER> when ..."`
+- Controllers: `"should respond <HTTP_STATUS_CODE> (<HTTP_STATUS>) when ..."`
+- Services/Repositories: `"should ... when ..."` -- at least one success and one failure test per public method.
+
+### Test Doubles (preference order)
+
+1. **Stubs** -- return pre-configured (canned) answers. No in-memory logic.
+2. **Dummies** -- fill required parameters that are never used. Return minimal values.
+3. **In-memory** -- implement logic in memory without external modules.
+4. **Fakers** -- generate realistic fake data via an external library.
+5. **Mocks** -- record and verify method calls. **Avoid when possible.**
+
+### Builders
+
+Use the Builder Design Pattern for constructing complex test objects:
+```
+UserBuilder.new().withName("John Doe").withEmail("john@example.com").build()
+```
+
+## Documentation
+
+Every code change must include corresponding documentation updates:
+
+1. **`CHANGELOG.md`** -- always. Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Add entries under `[Unreleased]` with categories: Added, Changed, Deprecated, Removed, Fixed, Security. Start each entry with a lowercase verb in simple past tense. Be specific.
+2. **`README.md`** -- when behavior, configuration, CLI, or setup changes.
+3. **`CONTRIBUTING.md`** -- when prerequisites, workflow, or project structure changes.
+4. **AI instruction files** (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `.github/copilot-instructions.md`) -- when architecture, commands, or development workflow changes.
+
+Documentation and code ship as one unit in the same commit. Never merge a PR that introduces user-facing or architectural changes without the corresponding documentation update.
+
+## YAML Conventions
+
+- Always use `.yaml` extension (never `.yml`). Exception only when the tool enforces `.yml` (e.g., Azure DevOps `azure-pipelines.yml`).
+- Always single-quote strings: `name: 'my-service'`.
+- Double quotes only for interpolation or escape sequences: `url: "${API_HOST}/v1"`, `message: "line1\nline2"`.
+- Never quote booleans or numbers: `enabled: true`, `replicas: 3`.
+- These rules apply to all YAML: CI/CD pipelines, Kubernetes manifests, Docker Compose, Helm values, application configs, and YAML code blocks inside Markdown.
+
+## Security
+
+- Never hard-code secrets, API keys, tokens, or passwords. Use environment variables or secret managers (1Password, Vault, AWS Secrets Manager).
+- Follow OWASP Top 10 guidelines: validate and sanitize all user input, use parameterized queries, enforce MFA, implement RBAC, use HTTPS/TLS, encrypt data at rest.
+- Run `make sast` before every push. The SAST suite includes CodeQL, Semgrep, Trivy, Hadolint, and Gitleaks.
+- If Gitleaks detects a leaked secret, rotate the credential immediately.
+- Use `.env` files for local development but never commit them.
+
+## Language-Specific Conventions
+
+### Go
+
+- **File names:** `snake_case` (e.g., `list_users_command.go`).
+- **Method receivers:** one or two letter abbreviation of the type (`c` for `Command`, `r` for `Repository`). Never use `self`, `this`, or `me`.
+- **Entities:** framework-agnostic. No `json`, `gorm`, or other tags inside entity structs.
+- **DI:** use [Uber Dig](https://github.com/uber-go/dig). Each architectural layer has a `container.go` file for provider registration.
+- **Naming patterns:**
+  - Commands: `<operation>_<entity>_command.go` / `<Operation><Entity>Command` / method `Execute`.
+  - Controllers: `<operation>_<entity>_controller.go` / `<Operation><Entity>Controller` / method `Execute`.
+  - Repositories (contract): `<entity>_repository.go` / `<Entity>Repository` (interface).
+  - Repositories (impl): `<library>_<entity>_repository.go` / `<Library><Entity>Repository`.
+  - Mappers: `<entity>_mapper.go` / `<Entity>Mapper`.
+  - Models: prefixed with external tool name (e.g., `PgxUser`, `AwsFile`).
+- **Linting:** `golangci-lint`.
+- **Logging:** `Logrus`.
+- **Testing:** `testify` (assert + suite + mock).
+- **Services layer:** not used in Go projects.
+- **Repository methods:** `FindByField`, `FindAllByField`, `HasCondition`, `Save`, `SaveAll`, `DeleteByField`.
+- **Project structure:** `cmd/<app>/` (entry point + `dig.go`), `internal/domain/`, `internal/infrastructure/`, `test/` (builders, doubles, helpers).
+
+### JavaScript / TypeScript
+
+- **File names:** `snake_case` (e.g., `my_class.js`).
+- **HTML attributes:** `camelCase` for `id` and `data-test-subj` values.
+- **Formatting:** Prettier. **Linting:** ESLint.
+- Prefer arrow functions, template strings, spread operator, optional chaining (`?.`), nullish coalescing (`??`).
+- **Never use `any`** -- use `unknown` with type narrowing instead.
+- **Immutability:** do not reassign variables, modify object properties, or push to arrays. Create new copies.
+- **Destructuring:** use object and array destructuring instead of index access.
+
+### Java
+
+- **File names:** `PascalCase` (matches class name, e.g., `ListItemsCommand.java`).
+- **Framework:** Spring Boot.
+- **DI:** constructor injection via Lombok `@RequiredArgsConstructor`. **Never** use field injection (`@Autowired` on fields). Mark injected fields as `final`.
+- **Annotations:** `@Component` for commands/listeners, `@RestController` for controllers, `@Repository` for repositories, `@Service` for services.
+- **Mapping:** MapStruct with `@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)` and `INSTANCE` pattern.
+- **Entities:** no `@Entity`, `@Table`, `@Column`, or JPA annotations. Use Java records for DTOs and value objects.
+- **Models:** prefixed with `Jpa` (e.g., `JpaItem`). Annotated with `@Entity`, `@Getter`, `@Setter`, `@SuperBuilder`, `@NoArgsConstructor`.
+- **Naming patterns:**
+  - Commands: `<Operation><Entity>Command.java` / method `execute` / inner `Listeners` record.
+  - Controllers: `<Operation><Entity>Controller.java` / method `execute`.
+  - Services (contract): `<Operation><Entity>Service.java` (interface).
+  - Services (impl): `Jpa<Operation><Entity>Service.java`.
+  - Repositories (contract): `<Entity>Repository.java` (interface).
+  - Repositories (impl): `Jpa<Entity>Repository.java` (extends `JpaRepository`).
+- **Formatting:** Google Java Format via Spotless. **Linting:** Checkstyle + PMD.
+- **Logging:** SLF4J with Logback.
+- **Testing:** JUnit 5 + Mockito.
+- **Build:** Gradle (always use `gradlew` wrapper).
+- **Database:** Liquibase with `.yaml` format, `snake_case` names, single quotes, rollback + pre-conditions on every changeset, constraints before column name.
+- **Principles:** program to interfaces, favor composition over inheritance, immutability by default (`final`), fail fast, convention over configuration.
+
+### Python
+
+- **File names:** `snake_case` (e.g., `list_users_command.py`). Package names cannot contain dashes.
+- **Classes:** `PascalCase`.
+- **Formatting:** Black. **Import sorting:** isort. **Linting:** Flake8.
+- **Type hints:** required on all function signatures.
+- **Logging:** Loguru.
+- **Testing:** pytest.
+- **Package manager:** PDM with PEP 621 metadata in `pyproject.toml`.
+- **Entities:** framework-agnostic, no ORM base classes or decorators.
+- **Naming patterns:**
+  - Commands: `<operation>_<entity>_command.py` / `<Operation><Entity>Command` / method `execute`.
+  - Controllers: `<operation>_<entity>_controller.py` / `<Operation><Entity>Controller` / method `execute`.
+  - Repositories (contract): `<entity>_repository.py` / `<Entity>Repository` (ABC with `@abstractmethod`).
+  - Repositories (impl): `<library>_<entity>_repository.py` / `<Library><Entity>Repository`.
+- **DI:** constructor injection. Use framework DI (e.g., FastAPI) or wire manually in composition root.
+- Use descriptive variable names. Write comments that explain **why**, not just **what**.
+
+## Code Review Guardrails
+
+When reviewing code, enforce these rules:
+
+1. **Architecture violations:** entities must not import from infrastructure. Dependencies must point inward.
+2. **Framework leakage:** no ORM annotations, framework tags, or external tool dependencies inside domain entities.
+3. **Naming consistency:** operations vocabulary (`List`, `Get`, `Insert`, `Update`, `Delete`) must be used. File and class naming must follow language-specific patterns.
+4. **Test quality:** every test must have `given`/`when`/`then` blocks. Prefer stubs over mocks. At least one success + one failure test per public method.
+5. **Documentation:** changelog entry is mandatory. README update is mandatory when behavior changes.
+6. **Commit format:** `type(SCOPE): message` in simple past tense.
+7. **Security:** no hardcoded secrets, parameterized queries, input validation present.
+8. **YAML:** `.yaml` extension, single-quoted strings, unquoted booleans/numbers.
+9. **Immutability:** `final` fields in Java, no mutation in JS/TS, constructor injection everywhere.
+10. **Layer isolation:** mappers exist between layers, no direct coupling between controllers and repositories.
+````
+
+## References
+
+- [Documentation & Change Control](../Documentation-&-Change-Control.md)
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [Development Guide Wiki](https://github.com/rios0rios0/guide/wiki)

--- a/Life-Cycle/Documentation-&-Change-Control/Cursorrules-Template.md
+++ b/Life-Cycle/Documentation-&-Change-Control/Cursorrules-Template.md
@@ -1,0 +1,237 @@
+# Cursorrules Template
+
+> **TL;DR:** Copy the template below into a `.cursorrules` file at the project root. This file gives [Cursor](https://cursor.sh/) the full team development standards so it can write code, review PRs, and enforce conventions automatically -- no manual intervention needed.
+
+## Overview
+
+Cursor reads `.cursorrules` from the project root to understand project conventions. This template embeds the entire [Development Guide](https://github.com/rios0rios0/guide/wiki) so that Cursor already knows every convention, architecture pattern, and language-specific rule the team follows. Install it via `install-ai-rules.sh` or copy the content below.
+
+**Note:** Cursor also supports `.cursor/rules/*.mdc` for modular rules. The `.cursorrules` file is the simplest and most compatible approach.
+
+## Template
+
+````text
+# Commands
+
+- `make lint` -- fix all linter issues
+- `make test` -- run the full test suite
+- `make sast` -- run the complete SAST security suite
+
+Always run lint, test, and sast before considering any task complete.
+
+# Architecture
+
+Follow Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design (DDD) and CQRS.
+
+## Layer Separation
+
+- `domain/` contains contracts: entities, repository interfaces, service interfaces, and commands.
+- `infrastructure/` contains implementations: controllers, repository implementations, service implementations, and mappers.
+- Dependencies always point inward -- infrastructure depends on domain, never the reverse.
+- Entities must be framework-agnostic. No ORM annotations, no framework tags, no external dependencies inside entity definitions.
+
+## Principal Actors
+
+- Entities: core business objects with domain rules. Framework-agnostic. No persistence annotations.
+- Controllers: bridge between view (client) and business layer. Delegate to commands.
+- Commands: implement business/feature logic. Apply domain rules. Define Listeners for callback outcomes.
+- Services: handle application-level concerns (parsing, conversions). Domain defines contract, infrastructure implements.
+- Repositories: abstract all data access behind domain-defined interfaces.
+
+## Mappers
+
+Use mappers to isolate layers. Never let framework types leak across layer boundaries:
+- Repository mappers: convert between infrastructure models (prefixed with tool name, e.g., PgxUser, JpaItem) and domain entities.
+- Controller mappers: convert between request/response DTOs and domain entities. Separate request mappers from response mappers.
+
+## File Structure Tiers
+
+Minimal: domain/commands, domain/entities, domain/repositories, infrastructure/repositories.
+Intermediate: add domain/services and infrastructure/services.
+Complete: add infrastructure/controllers (with requests/, responses/, mappers/), infrastructure/repositories/mappers and models/.
+
+## Frontend Architecture
+
+5-layer lightweight Clean Architecture: Domain, Service, Infrastructure, Presentation, Main.
+Dependencies always point toward Domain. Main handles DI wiring.
+
+# Operations Vocabulary
+
+Use these standard prefixes for naming files, classes, and methods:
+
+- List: retrieve multiple records
+- Get: retrieve a single record
+- Insert: create a single record
+- Update: modify a single record
+- Delete: remove a single record
+- BatchInsert: create multiple records
+- BatchUpdate: modify multiple records
+- BatchDelete: remove multiple records
+- DeleteAll: remove all records
+
+# Git Conventions
+
+## Commit Messages
+
+Format: `type(SCOPE): message`
+
+- SCOPE is the task ID (e.g., TICKET-123) or a short descriptive scope.
+- Use simple past tense: added, changed, fixed, removed.
+- No period at the end. Do not capitalize the first letter.
+- Wrap code references in backticks.
+- Types: feat, fix, refactor, chore, test, docs.
+- Long messages: body with bullet points starting with lowercase verb in past tense.
+
+## Branches
+
+Format: `type/TICKET-ID` or `type/short-description` (e.g., feat/TICKET-000, fix/input-mask).
+
+## Branch Synchronization
+
+Always use `git rebase` to synchronize with main. Never merge main into feature branches.
+
+## Breaking Changes
+
+Flag in three places: commit footer (BREAKING CHANGE: description), CHANGELOG.md entry, PR description.
+
+## Semantic Versioning
+
+- MAJOR (X.0.0): breaking changes, new native modules, drastic structural changes.
+- MINOR (0.X.0): incremental features, no breaking changes.
+- PATCH (0.0.X): bug fixes in production only.
+
+# Testing
+
+## BDD Pattern (mandatory)
+
+All tests must use clearly separated comment blocks:
+- Go / JavaScript / TypeScript / Java: `// given`, `// when`, `// then`
+- Python: `# given`, `# when`, `# then`
+
+## Test Descriptions
+
+- Commands: "should call <LISTENER> when ..."
+- Controllers: "should respond <HTTP_STATUS_CODE> (<HTTP_STATUS>) when ..."
+- Services/Repositories: "should ... when ..." -- at least one success and one failure test per public method.
+
+## Test Doubles (preference order)
+
+1. Stubs -- return pre-configured (canned) answers. No in-memory logic.
+2. Dummies -- fill required parameters that are never used. Return minimal values.
+3. In-memory -- implement logic in memory without external modules.
+4. Fakers -- generate realistic fake data via an external library.
+5. Mocks -- record and verify method calls. Avoid when possible.
+
+## Builders
+
+Use Builder Design Pattern for constructing complex test objects:
+UserBuilder.new().withName("John Doe").withEmail("john@example.com").build()
+
+# Documentation
+
+Every code change must include corresponding documentation updates:
+
+1. CHANGELOG.md -- always. Follow Keep a Changelog format. Add entries under [Unreleased]. Categories: Added, Changed, Deprecated, Removed, Fixed, Security. Start with lowercase verb in simple past tense.
+2. README.md -- when behavior, configuration, CLI, or setup changes.
+3. CONTRIBUTING.md -- when prerequisites, workflow, or project structure changes.
+4. AI instruction files (CLAUDE.md, .cursorrules, AGENTS.md, .github/copilot-instructions.md) -- when architecture, commands, or development workflow changes.
+
+Documentation and code ship as one unit in the same commit.
+
+# YAML Conventions
+
+- Always use `.yaml` extension (never `.yml`). Exception only when tool enforces `.yml`.
+- Always single-quote strings: `name: 'my-service'`.
+- Double quotes only for interpolation or escape sequences: `url: "${API_HOST}/v1"`.
+- Never quote booleans or numbers: `enabled: true`, `replicas: 3`.
+- Applies to all YAML: CI/CD pipelines, Kubernetes manifests, Docker Compose, Helm, app configs, YAML in Markdown.
+
+# Security
+
+- Never hard-code secrets, API keys, tokens, or passwords. Use environment variables or secret managers.
+- Follow OWASP Top 10: validate/sanitize all user input, parameterized queries, enforce MFA, RBAC, HTTPS/TLS, encrypt at rest.
+- Run `make sast` before every push. Suite: CodeQL, Semgrep, Trivy, Hadolint, Gitleaks.
+- Rotate leaked secrets immediately. Never commit `.env` files.
+
+# Language-Specific Conventions
+
+## Go
+
+- File names: snake_case (e.g., list_users_command.go).
+- Method receivers: one/two letter abbreviation of type (c for Command, r for Repository). Never self/this/me.
+- Entities: framework-agnostic. No json/gorm/other tags inside entity structs.
+- DI: Uber Dig. Each layer has container.go for provider registration.
+- Commands: <operation>_<entity>_command.go / <Operation><Entity>Command / method Execute.
+- Controllers: <operation>_<entity>_controller.go / <Operation><Entity>Controller / method Execute.
+- Repositories (contract): <entity>_repository.go / <Entity>Repository (interface).
+- Repositories (impl): <library>_<entity>_repository.go / <Library><Entity>Repository.
+- Mappers: <entity>_mapper.go / <Entity>Mapper.
+- Models: prefixed with external tool name (PgxUser, AwsFile).
+- Linting: golangci-lint. Logging: Logrus. Testing: testify.
+- Services layer: not used in Go projects.
+- Repository methods: FindByField, FindAllByField, HasCondition, Save, SaveAll, DeleteByField.
+- Structure: cmd/<app>/ (main.go + dig.go), internal/domain/, internal/infrastructure/, test/ (builders, doubles, helpers).
+
+## JavaScript / TypeScript
+
+- File names: snake_case (e.g., my_class.js).
+- HTML attributes: camelCase for id and data-test-subj values.
+- Formatting: Prettier. Linting: ESLint.
+- Prefer arrow functions, template strings, spread operator, optional chaining (?.), nullish coalescing (??).
+- Never use `any` -- use `unknown` with type narrowing.
+- Immutability: do not reassign variables, modify object properties, or push to arrays. Create new copies.
+- Use object and array destructuring.
+
+## Java
+
+- File names: PascalCase (matches class name).
+- Framework: Spring Boot. Build: Gradle (always use gradlew).
+- DI: constructor injection via Lombok @RequiredArgsConstructor. Never field injection (@Autowired on fields). Mark fields final.
+- Annotations: @Component for commands/listeners, @RestController for controllers, @Repository for repos, @Service for services.
+- Mapping: MapStruct with INSTANCE pattern.
+- Entities: no @Entity/@Table/@Column/JPA annotations. Use records for DTOs.
+- Models: prefixed Jpa (JpaItem). Annotated @Entity/@Getter/@Setter/@SuperBuilder/@NoArgsConstructor.
+- Commands: <Operation><Entity>Command.java / execute / inner Listeners record.
+- Controllers: <Operation><Entity>Controller.java / execute.
+- Services (contract): <Operation><Entity>Service.java (interface). Impl: Jpa<Operation><Entity>Service.java.
+- Repositories (contract): <Entity>Repository.java. Impl: Jpa<Entity>Repository.java.
+- Formatting: Google Java Format via Spotless. Linting: Checkstyle + PMD.
+- Logging: SLF4J with Logback. Testing: JUnit 5 + Mockito.
+- Database: Liquibase (.yaml, snake_case, single quotes, rollback + pre-conditions, constraints before column name).
+- Principles: program to interfaces, composition over inheritance, immutability (final), fail fast.
+
+## Python
+
+- File names: snake_case. Package names cannot contain dashes.
+- Classes: PascalCase.
+- Formatting: Black. Import sorting: isort. Linting: Flake8.
+- Type hints: required on all function signatures.
+- Logging: Loguru. Testing: pytest. Package manager: PDM (PEP 621, pyproject.toml).
+- Entities: framework-agnostic, no ORM base classes or decorators.
+- Commands: <operation>_<entity>_command.py / <Operation><Entity>Command / execute.
+- Controllers: <operation>_<entity>_controller.py / <Operation><Entity>Controller / execute.
+- Repositories (contract): <entity>_repository.py / <Entity>Repository (ABC with @abstractmethod).
+- Repositories (impl): <library>_<entity>_repository.py / <Library><Entity>Repository.
+- Use descriptive variable names. Write comments that explain why, not just what.
+
+# Code Review Guardrails
+
+When reviewing code, enforce:
+
+1. Architecture violations: entities must not import from infrastructure. Dependencies point inward.
+2. Framework leakage: no ORM/framework annotations inside domain entities.
+3. Naming consistency: operations vocabulary (List, Get, Insert, Update, Delete). Language-specific naming patterns.
+4. Test quality: given/when/then blocks. Prefer stubs over mocks. Success + failure tests per public method.
+5. Documentation: changelog entry mandatory. README update when behavior changes.
+6. Commit format: type(SCOPE): message in simple past tense.
+7. Security: no hardcoded secrets, parameterized queries, input validation.
+8. YAML: .yaml extension, single-quoted strings, unquoted booleans/numbers.
+9. Immutability: final fields in Java, no mutation in JS/TS, constructor injection everywhere.
+10. Layer isolation: mappers between layers, no direct coupling between controllers and repositories.
+````
+
+## References
+
+- [Documentation & Change Control](../Documentation-&-Change-Control.md)
+- [Cursor Rules Documentation](https://docs.cursor.com/context/rules-for-ai)
+- [Development Guide Wiki](https://github.com/rios0rios0/guide/wiki)

--- a/install-ai-rules.sh
+++ b/install-ai-rules.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install-ai-rules.sh
+# Installs AI assistant rule files (CLAUDE.md, .cursorrules, AGENTS.md)
+# into the target project directory. Overwrites existing files with the same name.
+#
+# Usage:
+#   ./install-ai-rules.sh [target-directory]
+#
+# If no target directory is provided, uses the current working directory.
+# The installed files contain the full development guide conventions so that
+# AI agents (Claude Code, Cursor, OpenAI Codex) can write code, review PRs,
+# and enforce standards without any manual configuration.
+
+TARGET_DIR="${1:-.}"
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+
+echo "Installing AI rule files into: $TARGET_DIR"
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md
+# ---------------------------------------------------------------------------
+cat > "$TARGET_DIR/CLAUDE.md" << 'EOF'
+# CLAUDE.md
+
+## Commands
+
+```bash
+make lint    # fix all linter issues
+make test    # run the full test suite
+make sast    # run the complete SAST security suite
+```
+
+Always run lint, test, and sast before considering any task complete.
+
+## Architecture
+
+Follow **Hexagonal Architecture (Ports & Adapters)** with **Domain-Driven Design (DDD)** and **CQRS**.
+
+### Layer Separation
+
+- `domain/` contains contracts: entities, repository interfaces, service interfaces, and commands.
+- `infrastructure/` contains implementations: controllers, repository implementations, service implementations, and mappers.
+- Dependencies always point inward -- infrastructure depends on domain, never the reverse.
+- Entities must be **framework-agnostic**. No ORM annotations, no framework tags, no external dependencies inside entity definitions.
+
+### Principal Actors
+
+| Actor            | Responsibility                                                                                                    |
+|------------------|-------------------------------------------------------------------------------------------------------------------|
+| **Entities**     | Core business objects. Contain domain rules about what the modeled objects are and how they behave. Framework-agnostic. |
+| **Controllers**  | Bridge between the view (client) and the business layer. Receive requests and delegate to commands.               |
+| **Commands**     | Implement business/feature logic and apply domain rules. Define a `Listeners` record for callback outcomes.       |
+| **Services**     | Handle application-level concerns: parsing, conversions, transformations. Domain layer defines the contract (interface), infrastructure provides the implementation. |
+| **Repositories** | Abstract all data access. Changing the database technology requires modifying only the repository implementation. |
+
+### Mappers
+
+Use mappers to isolate layers. Never let framework types leak across layer boundaries:
+- **Repository mappers:** convert between infrastructure models (prefixed with tool name, e.g., `PgxUser`, `JpaItem`) and domain entities.
+- **Controller mappers:** convert between request/response DTOs and domain entities. Separate request mappers from response mappers.
+
+### File Structure Tiers
+
+Scale structure with complexity:
+
+**Minimal (3 layers):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+infrastructure/repositories/
+```
+
+**Intermediate (with Services):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+domain/services/
+infrastructure/repositories/
+infrastructure/services/
+```
+
+**Complete (with API layer):**
+```
+domain/commands/
+domain/entities/
+domain/repositories/
+domain/services/
+infrastructure/controllers/
+infrastructure/controllers/requests/
+infrastructure/controllers/responses/
+infrastructure/controllers/mappers/
+infrastructure/repositories/
+infrastructure/repositories/mappers/
+infrastructure/repositories/models/
+infrastructure/services/
+infrastructure/services/mappers/
+```
+
+### Frontend Architecture
+
+5-layer lightweight Clean Architecture:
+- **Domain** -- most abstract layer, defines entities and contracts.
+- **Service** -- communication with APIs and external services.
+- **Infrastructure** -- technology-specific implementations.
+- **Presentation** -- view-rendering code (components, pages, hooks).
+- **Main** -- wiring layer, instantiates providers and services, handles DI.
+
+Dependencies always point toward Domain.
+
+## Operations Vocabulary
+
+Use these standard prefixes consistently for naming files, classes, and methods:
+
+| Operation     | Description               |
+|---------------|---------------------------|
+| `List`        | Retrieve multiple records |
+| `Get`         | Retrieve a single record  |
+| `Insert`      | Create a single record    |
+| `Update`      | Modify a single record    |
+| `Delete`      | Remove a single record    |
+| `BatchInsert` | Create multiple records   |
+| `BatchUpdate` | Modify multiple records   |
+| `BatchDelete` | Remove multiple records   |
+| `DeleteAll`   | Remove all records        |
+
+## Git Conventions
+
+### Commit Messages
+
+Format: `type(SCOPE): message`
+
+- **SCOPE** is the task ID (e.g., `TICKET-123`) or a short descriptive scope.
+- Use **simple past tense**: `added`, `changed`, `fixed`, `removed`.
+- **No period** at the end. **Do not capitalize** the first letter.
+- Wrap code references in backticks.
+
+Types: `feat`, `fix`, `refactor`, `chore`, `test`, `docs`.
+
+Long commit messages use a body with bullet points starting with a lowercase verb in past tense.
+
+### Branches
+
+Format: `type/TICKET-ID` or `type/short-description` (e.g., `feat/TICKET-000`, `fix/input-mask`).
+
+### Branch Synchronization
+
+Always use `git rebase` to synchronize with `main`. Never merge `main` into feature branches.
+
+### Breaking Changes
+
+Flag in three places:
+1. Commit footer: `**BREAKING CHANGE:** description`
+2. `CHANGELOG.md` entry: `- **BREAKING CHANGE:** description`
+3. PR description: `**BREAKING CHANGE:** description`
+
+### Semantic Versioning
+
+- **MAJOR** (`X.0.0`): breaking changes, new native modules, drastic structural changes.
+- **MINOR** (`0.X.0`): incremental features, no breaking changes.
+- **PATCH** (`0.0.X`): bug fixes in production only.
+
+## Testing
+
+### BDD Pattern (mandatory)
+
+All tests must use clearly separated comment blocks:
+
+| Language                | Given      | When      | Then      |
+|-------------------------|------------|-----------|-----------||
+| Go                      | `// given` | `// when` | `// then` |
+| JavaScript / TypeScript | `// given` | `// when` | `// then` |
+| Java                    | `// given` | `// when` | `// then` |
+| Python                  | `# given`  | `# when`  | `# then`  |
+
+### Test Descriptions
+
+- Commands: `"should call <LISTENER> when ..."`
+- Controllers: `"should respond <HTTP_STATUS_CODE> (<HTTP_STATUS>) when ..."`
+- Services/Repositories: `"should ... when ..."` -- at least one success and one failure test per public method.
+
+### Test Doubles (preference order)
+
+1. **Stubs** -- return pre-configured (canned) answers. No in-memory logic.
+2. **Dummies** -- fill required parameters that are never used. Return minimal values.
+3. **In-memory** -- implement logic in memory without external modules.
+4. **Fakers** -- generate realistic fake data via an external library.
+5. **Mocks** -- record and verify method calls. **Avoid when possible.**
+
+### Builders
+
+Use the Builder Design Pattern for constructing complex test objects:
+```
+UserBuilder.new().withName("John Doe").withEmail("john@example.com").build()
+```
+
+## Documentation
+
+Every code change must include corresponding documentation updates:
+
+1. **`CHANGELOG.md`** -- always. Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Add entries under `[Unreleased]` with categories: Added, Changed, Deprecated, Removed, Fixed, Security. Start each entry with a lowercase verb in simple past tense. Be specific.
+2. **`README.md`** -- when behavior, configuration, CLI, or setup changes.
+3. **`CONTRIBUTING.md`** -- when prerequisites, workflow, or project structure changes.
+4. **AI instruction files** (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `.github/copilot-instructions.md`) -- when architecture, commands, or development workflow changes.
+
+Documentation and code ship as one unit in the same commit. Never merge a PR that introduces user-facing or architectural changes without the corresponding documentation update.
+
+## YAML Conventions
+
+- Always use `.yaml` extension (never `.yml`). Exception only when the tool enforces `.yml` (e.g., Azure DevOps `azure-pipelines.yml`).
+- Always single-quote strings: `name: 'my-service'`.
+- Double quotes only for interpolation or escape sequences: `url: "${API_HOST}/v1"`, `message: "line1\nline2"`.
+- Never quote booleans or numbers: `enabled: true`, `replicas: 3`.
+- These rules apply to all YAML: CI/CD pipelines, Kubernetes manifests, Docker Compose, Helm values, application configs, and YAML code blocks inside Markdown.
+
+## Security
+
+- Never hard-code secrets, API keys, tokens, or passwords. Use environment variables or secret managers (1Password, Vault, AWS Secrets Manager).
+- Follow OWASP Top 10 guidelines: validate and sanitize all user input, use parameterized queries, enforce MFA, implement RBAC, use HTTPS/TLS, encrypt data at rest.
+- Run `make sast` before every push. The SAST suite includes CodeQL, Semgrep, Trivy, Hadolint, and Gitleaks.
+- If Gitleaks detects a leaked secret, rotate the credential immediately.
+- Use `.env` files for local development but never commit them.
+
+## Language-Specific Conventions
+
+### Go
+
+- **File names:** `snake_case` (e.g., `list_users_command.go`).
+- **Method receivers:** one or two letter abbreviation of the type (`c` for `Command`, `r` for `Repository`). Never use `self`, `this`, or `me`.
+- **Entities:** framework-agnostic. No `json`, `gorm`, or other tags inside entity structs.
+- **DI:** use [Uber Dig](https://github.com/uber-go/dig). Each architectural layer has a `container.go` file for provider registration.
+- **Naming patterns:**
+  - Commands: `<operation>_<entity>_command.go` / `<Operation><Entity>Command` / method `Execute`.
+  - Controllers: `<operation>_<entity>_controller.go` / `<Operation><Entity>Controller` / method `Execute`.
+  - Repositories (contract): `<entity>_repository.go` / `<Entity>Repository` (interface).
+  - Repositories (impl): `<library>_<entity>_repository.go` / `<Library><Entity>Repository`.
+  - Mappers: `<entity>_mapper.go` / `<Entity>Mapper`.
+  - Models: prefixed with external tool name (e.g., `PgxUser`, `AwsFile`).
+- **Linting:** `golangci-lint`.
+- **Logging:** `Logrus`.
+- **Testing:** `testify` (assert + suite + mock).
+- **Services layer:** not used in Go projects.
+- **Repository methods:** `FindByField`, `FindAllByField`, `HasCondition`, `Save`, `SaveAll`, `DeleteByField`.
+- **Project structure:** `cmd/<app>/` (entry point + `dig.go`), `internal/domain/`, `internal/infrastructure/`, `test/` (builders, doubles, helpers).
+
+### JavaScript / TypeScript
+
+- **File names:** `snake_case` (e.g., `my_class.js`).
+- **HTML attributes:** `camelCase` for `id` and `data-test-subj` values.
+- **Formatting:** Prettier. **Linting:** ESLint.
+- Prefer arrow functions, template strings, spread operator, optional chaining (`?.`), nullish coalescing (`??`).
+- **Never use `any`** -- use `unknown` with type narrowing instead.
+- **Immutability:** do not reassign variables, modify object properties, or push to arrays. Create new copies.
+- **Destructuring:** use object and array destructuring instead of index access.
+
+### Java
+
+- **File names:** `PascalCase` (matches class name, e.g., `ListItemsCommand.java`).
+- **Framework:** Spring Boot.
+- **DI:** constructor injection via Lombok `@RequiredArgsConstructor`. **Never** use field injection (`@Autowired` on fields). Mark injected fields as `final`.
+- **Annotations:** `@Component` for commands/listeners, `@RestController` for controllers, `@Repository` for repositories, `@Service` for services.
+- **Mapping:** MapStruct with `@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)` and `INSTANCE` pattern.
+- **Entities:** no `@Entity`, `@Table`, `@Column`, or JPA annotations. Use Java records for DTOs and value objects.
+- **Models:** prefixed with `Jpa` (e.g., `JpaItem`). Annotated with `@Entity`, `@Getter`, `@Setter`, `@SuperBuilder`, `@NoArgsConstructor`.
+- **Naming patterns:**
+  - Commands: `<Operation><Entity>Command.java` / method `execute` / inner `Listeners` record.
+  - Controllers: `<Operation><Entity>Controller.java` / method `execute`.
+  - Services (contract): `<Operation><Entity>Service.java` (interface).
+  - Services (impl): `Jpa<Operation><Entity>Service.java`.
+  - Repositories (contract): `<Entity>Repository.java` (interface).
+  - Repositories (impl): `Jpa<Entity>Repository.java` (extends `JpaRepository`).
+- **Formatting:** Google Java Format via Spotless. **Linting:** Checkstyle + PMD.
+- **Logging:** SLF4J with Logback.
+- **Testing:** JUnit 5 + Mockito.
+- **Build:** Gradle (always use `gradlew` wrapper).
+- **Database:** Liquibase with `.yaml` format, `snake_case` names, single quotes, rollback + pre-conditions on every changeset, constraints before column name.
+- **Principles:** program to interfaces, favor composition over inheritance, immutability by default (`final`), fail fast, convention over configuration.
+
+### Python
+
+- **File names:** `snake_case` (e.g., `list_users_command.py`). Package names cannot contain dashes.
+- **Classes:** `PascalCase`.
+- **Formatting:** Black. **Import sorting:** isort. **Linting:** Flake8.
+- **Type hints:** required on all function signatures.
+- **Logging:** Loguru.
+- **Testing:** pytest.
+- **Package manager:** PDM with PEP 621 metadata in `pyproject.toml`.
+- **Entities:** framework-agnostic, no ORM base classes or decorators.
+- **Naming patterns:**
+  - Commands: `<operation>_<entity>_command.py` / `<Operation><Entity>Command` / method `execute`.
+  - Controllers: `<operation>_<entity>_controller.py` / `<Operation><Entity>Controller` / method `execute`.
+  - Repositories (contract): `<entity>_repository.py` / `<Entity>Repository` (ABC with `@abstractmethod`).
+  - Repositories (impl): `<library>_<entity>_repository.py` / `<Library><Entity>Repository`.
+- **DI:** constructor injection. Use framework DI (e.g., FastAPI) or wire manually in composition root.
+- Use descriptive variable names. Write comments that explain **why**, not just **what**.
+
+## Code Review Guardrails
+
+When reviewing code, enforce these rules:
+
+1. **Architecture violations:** entities must not import from infrastructure. Dependencies must point inward.
+2. **Framework leakage:** no ORM annotations, framework tags, or external tool dependencies inside domain entities.
+3. **Naming consistency:** operations vocabulary (`List`, `Get`, `Insert`, `Update`, `Delete`) must be used. File and class naming must follow language-specific patterns.
+4. **Test quality:** every test must have `given`/`when`/`then` blocks. Prefer stubs over mocks. At least one success + one failure test per public method.
+5. **Documentation:** changelog entry is mandatory. README update is mandatory when behavior changes.
+6. **Commit format:** `type(SCOPE): message` in simple past tense.
+7. **Security:** no hardcoded secrets, parameterized queries, input validation present.
+8. **YAML:** `.yaml` extension, single-quoted strings, unquoted booleans/numbers.
+9. **Immutability:** `final` fields in Java, no mutation in JS/TS, constructor injection everywhere.
+10. **Layer isolation:** mappers exist between layers, no direct coupling between controllers and repositories.
+EOF
+echo "  -> wrote CLAUDE.md"
+
+# ---------------------------------------------------------------------------
+# .cursorrules (same content, plain text without the heading)
+# ---------------------------------------------------------------------------
+# Strip the first two lines (# CLAUDE.md and blank line) to produce .cursorrules
+tail -n +3 "$TARGET_DIR/CLAUDE.md" > "$TARGET_DIR/.cursorrules"
+echo "  -> wrote .cursorrules"
+
+# ---------------------------------------------------------------------------
+# AGENTS.md (same content, different heading)
+# ---------------------------------------------------------------------------
+{
+  echo "# AGENTS.md"
+  tail -n +2 "$TARGET_DIR/CLAUDE.md"
+} > "$TARGET_DIR/AGENTS.md"
+echo "  -> wrote AGENTS.md"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+echo "Done. All AI rule files have been installed with the full development guide conventions."
+echo "Your AI agents (Claude Code, Cursor, OpenAI Codex) now know all the team standards."
+echo ""
+echo "Reference: https://github.com/rios0rios0/guide/wiki"


### PR DESCRIPTION
## Summary

- added complete AI rule templates (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`) that embed the **entire development guide** -- architecture, code style, testing, security, git conventions, YAML rules, and all language-specific conventions (Go, Java, Python, JavaScript/TypeScript)
- added `install-ai-rules.sh` shell script that installs all three rule files into any project directory with a single command, overwriting existing files
- expanded the Documentation & Change Control page with a comprehensive AI Assistant Instructions section covering all supported tools (GitHub Copilot, Claude Code, Cursor, OpenAI Codex)
- updated `Home.md` table of contents with links to the three new template pages

## Motivation

AI coding agents (Claude Code, Cursor, OpenAI Codex) read project-level rule files to understand conventions. Without these files, developers must manually correct AI-generated code to match team standards. By installing these rules, every AI agent immediately knows:

- Hexagonal Architecture / DDD / CQRS layer separation
- Operations vocabulary and naming patterns per language
- BDD testing pattern (given/when/then), test doubles hierarchy
- Git commit format, branch naming, semantic versioning
- YAML conventions, security requirements (OWASP, SAST)
- Code review guardrails (10 enforceable rules)

**No placeholders, no configuration** -- the rules are complete and ready to use out of the box.

## Usage

```bash
# One-liner install from GitHub
curl -fsSL https://raw.githubusercontent.com/rios0rios0/guide/main/install-ai-rules.sh | bash -s -- .

# Or clone and run locally
chmod +x install-ai-rules.sh
./install-ai-rules.sh /path/to/your/project
```

## Test plan

- [ ] verify `install-ai-rules.sh` runs successfully on a fresh project directory
- [ ] verify `CLAUDE.md`, `.cursorrules`, and `AGENTS.md` are generated with complete content
- [ ] verify the script overwrites existing files when re-run
- [ ] verify wiki links in `Home.md` and `Documentation-&-Change-Control.md` resolve correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 986bb7efceb102d6b4ee6946a9bceedef92fe33c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->