### PR TITLE
fix(docs): prohibit direct tool binaries, not make target

### DIFF
--- a/.ai/claude/rules/ci-cd.md
+++ b/.ai/claude/rules/ci-cd.md
@@ -31,7 +31,7 @@ make test    # Run the full test suite
 make sast    # Run the complete SAST security suite
 ```
 
-**Never invoke linters, test runners, or security tools directly.** Always use the Makefile targets to ensure consistency with CI.
+**Never call tool binaries (e.g., `golangci-lint`, `pytest`, `eslint`, `semgrep`) directly.** Always use the Makefile targets (`make lint`, `make test`, `make sast`), which invoke the [pipelines repository](https://github.com/rios0rios0/pipelines) scripts to load the correct configuration before running each tool.
 
 ## SAST Toolchain
 

--- a/.ai/codex/AGENTS.md
+++ b/.ai/codex/AGENTS.md
@@ -5219,7 +5219,7 @@ make test    # Run the full test suite
 make sast    # Run the complete SAST security suite
 ```
 
-**Never invoke linters, test runners, or security tools directly.** Always use the Makefile targets to ensure consistency with CI.
+**Never call tool binaries (e.g., `golangci-lint`, `pytest`, `eslint`, `semgrep`) directly.** Always use the Makefile targets (`make lint`, `make test`, `make sast`), which invoke the [pipelines repository](https://github.com/rios0rios0/pipelines) scripts to load the correct configuration before running each tool.
 
 ## SAST Toolchain
 

--- a/.ai/codex/rules/default.rules
+++ b/.ai/codex/rules/default.rules
@@ -21,75 +21,99 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["make", "semgrep"],
+    decision = "allow",
+    justification = "SAST through Makefile is the approved approach",
+)
+
+prefix_rule(
+    pattern = ["make", "trivy"],
+    decision = "allow",
+    justification = "SAST through Makefile is the approved approach",
+)
+
+prefix_rule(
+    pattern = ["make", "hadolint"],
+    decision = "allow",
+    justification = "SAST through Makefile is the approved approach",
+)
+
+prefix_rule(
+    pattern = ["make", "gitleaks"],
+    decision = "allow",
+    justification = "SAST through Makefile is the approved approach",
+)
+
+prefix_rule(
     pattern = ["golangci-lint"],
     decision = "forbidden",
-    justification = "Use `make lint` instead of running golangci-lint directly",
+    justification = "Do not call golangci-lint directly; use `make lint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["pytest"],
     decision = "forbidden",
-    justification = "Use `make test` instead of running pytest directly",
+    justification = "Do not call pytest directly; use `make test` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["black"],
     decision = "forbidden",
-    justification = "Use `make lint` instead of running black directly",
+    justification = "Do not call black directly; use `make lint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["ruff"],
     decision = "forbidden",
-    justification = "Use `make lint` instead of running ruff directly",
+    justification = "Do not call ruff directly; use `make lint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["eslint"],
     decision = "forbidden",
-    justification = "Use `make lint` instead of running eslint directly",
+    justification = "Do not call eslint directly; use `make lint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["prettier"],
     decision = "forbidden",
-    justification = "Use `make lint` instead of running prettier directly",
+    justification = "Do not call prettier directly; use `make lint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["jest"],
     decision = "forbidden",
-    justification = "Use `make test` instead of running jest directly",
+    justification = "Do not call jest directly; use `make test` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["checkstyle"],
     decision = "forbidden",
-    justification = "Use `make lint` instead of running checkstyle directly",
+    justification = "Do not call checkstyle directly; use `make lint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["semgrep"],
     decision = "forbidden",
-    justification = "Use `make sast` instead of running semgrep directly",
+    justification = "Do not call semgrep directly; use `make semgrep` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["trivy"],
     decision = "forbidden",
-    justification = "Use `make sast` instead of running trivy directly",
+    justification = "Do not call trivy directly; use `make trivy` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["gitleaks"],
     decision = "forbidden",
-    justification = "Use `make sast` instead of running gitleaks directly",
+    justification = "Do not call gitleaks directly; use `make gitleaks` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(
     pattern = ["hadolint"],
     decision = "forbidden",
-    justification = "Use `make sast` instead of running hadolint directly",
+    justification = "Do not call hadolint directly; use `make hadolint` which loads the correct configuration through the pipelines repository scripts",
 )
 
 prefix_rule(

--- a/.ai/cursor/rules/ci-cd.mdc
+++ b/.ai/cursor/rules/ci-cd.mdc
@@ -36,7 +36,7 @@ make test    # Run the full test suite
 make sast    # Run the complete SAST security suite
 ```
 
-**Never invoke linters, test runners, or security tools directly.** Always use the Makefile targets to ensure consistency with CI.
+**Never call tool binaries (e.g., `golangci-lint`, `pytest`, `eslint`, `semgrep`) directly.** Always use the Makefile targets (`make lint`, `make test`, `make sast`), which invoke the [pipelines repository](https://github.com/rios0rios0/pipelines) scripts to load the correct configuration before running each tool.
 
 ## SAST Toolchain
 

--- a/.github/workflows/generate-ai-rules/formatter.go
+++ b/.github/workflows/generate-ai-rules/formatter.go
@@ -84,32 +84,36 @@ type CodexRule struct {
 // CI/CD, security, and Git Flow guidelines.
 func codexRules() []CodexRule {
 	return []CodexRule{
-		// Enforce Makefile targets (CI/CD: "Never invoke linters, test runners, or security tools directly")
+		// Enforce Makefile targets (CI/CD: "Never call tool binaries directly")
 		{Pattern: []string{"make", "lint"}, Decision: "allow", Justification: "Linting through Makefile is the approved approach"},
 		{Pattern: []string{"make", "test"}, Decision: "allow", Justification: "Testing through Makefile is the approved approach"},
 		{Pattern: []string{"make", "sast"}, Decision: "allow", Justification: "SAST through Makefile is the approved approach"},
+		{Pattern: []string{"make", "semgrep"}, Decision: "allow", Justification: "SAST through Makefile is the approved approach"},
+		{Pattern: []string{"make", "trivy"}, Decision: "allow", Justification: "SAST through Makefile is the approved approach"},
+		{Pattern: []string{"make", "hadolint"}, Decision: "allow", Justification: "SAST through Makefile is the approved approach"},
+		{Pattern: []string{"make", "gitleaks"}, Decision: "allow", Justification: "SAST through Makefile is the approved approach"},
 
 		// Forbid direct linter/test runner invocation — Go
-		{Pattern: []string{"golangci-lint"}, Decision: "forbidden", Justification: "Use `make lint` instead of running golangci-lint directly"},
+		{Pattern: []string{"golangci-lint"}, Decision: "forbidden", Justification: "Do not call golangci-lint directly; use `make lint` which loads the correct configuration through the pipelines repository scripts"},
 
 		// Forbid direct linter/test runner invocation — Python
-		{Pattern: []string{"pytest"}, Decision: "forbidden", Justification: "Use `make test` instead of running pytest directly"},
-		{Pattern: []string{"black"}, Decision: "forbidden", Justification: "Use `make lint` instead of running black directly"},
-		{Pattern: []string{"ruff"}, Decision: "forbidden", Justification: "Use `make lint` instead of running ruff directly"},
+		{Pattern: []string{"pytest"}, Decision: "forbidden", Justification: "Do not call pytest directly; use `make test` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"black"}, Decision: "forbidden", Justification: "Do not call black directly; use `make lint` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"ruff"}, Decision: "forbidden", Justification: "Do not call ruff directly; use `make lint` which loads the correct configuration through the pipelines repository scripts"},
 
 		// Forbid direct linter/test runner invocation — JavaScript/TypeScript
-		{Pattern: []string{"eslint"}, Decision: "forbidden", Justification: "Use `make lint` instead of running eslint directly"},
-		{Pattern: []string{"prettier"}, Decision: "forbidden", Justification: "Use `make lint` instead of running prettier directly"},
-		{Pattern: []string{"jest"}, Decision: "forbidden", Justification: "Use `make test` instead of running jest directly"},
+		{Pattern: []string{"eslint"}, Decision: "forbidden", Justification: "Do not call eslint directly; use `make lint` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"prettier"}, Decision: "forbidden", Justification: "Do not call prettier directly; use `make lint` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"jest"}, Decision: "forbidden", Justification: "Do not call jest directly; use `make test` which loads the correct configuration through the pipelines repository scripts"},
 
 		// Forbid direct linter/test runner invocation — Java
-		{Pattern: []string{"checkstyle"}, Decision: "forbidden", Justification: "Use `make lint` instead of running checkstyle directly"},
+		{Pattern: []string{"checkstyle"}, Decision: "forbidden", Justification: "Do not call checkstyle directly; use `make lint` which loads the correct configuration through the pipelines repository scripts"},
 
-		// SAST tools — must go through `make sast`
-		{Pattern: []string{"semgrep"}, Decision: "forbidden", Justification: "Use `make sast` instead of running semgrep directly"},
-		{Pattern: []string{"trivy"}, Decision: "forbidden", Justification: "Use `make sast` instead of running trivy directly"},
-		{Pattern: []string{"gitleaks"}, Decision: "forbidden", Justification: "Use `make sast` instead of running gitleaks directly"},
-		{Pattern: []string{"hadolint"}, Decision: "forbidden", Justification: "Use `make sast` instead of running hadolint directly"},
+		// SAST tools — must go through their respective Makefile targets
+		{Pattern: []string{"semgrep"}, Decision: "forbidden", Justification: "Do not call semgrep directly; use `make semgrep` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"trivy"}, Decision: "forbidden", Justification: "Do not call trivy directly; use `make trivy` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"gitleaks"}, Decision: "forbidden", Justification: "Do not call gitleaks directly; use `make gitleaks` which loads the correct configuration through the pipelines repository scripts"},
+		{Pattern: []string{"hadolint"}, Decision: "forbidden", Justification: "Do not call hadolint directly; use `make hadolint` which loads the correct configuration through the pipelines repository scripts"},
 
 		// Git safety (Git Flow: force-push requires caution)
 		{Pattern: []string{"git", "push", "--force"}, Decision: "prompt", Justification: "Force pushing rewrites remote history. Confirm this is intentional."},

--- a/Life-Cycle/CI-&-CD.md
+++ b/Life-Cycle/CI-&-CD.md
@@ -31,7 +31,16 @@ make test    # Run the full test suite
 make sast    # Run the complete SAST security suite
 ```
 
-**Never call tool binaries (e.g., `golangci-lint`, `pytest`, `eslint`, `semgrep`) directly.** Always use the Makefile targets (`make lint`, `make test`, `make sast`), which invoke the [pipelines repository](https://github.com/rios0rios0/pipelines) scripts to load the correct configuration before running each tool.
+Individual SAST tools can also be run separately when you only need to check a specific category:
+
+```bash
+make semgrep   # Run Semgrep pattern-based analysis only
+make trivy     # Run Trivy IaC/dependency scanning only
+make hadolint  # Run Hadolint Dockerfile linting only
+make gitleaks  # Run Gitleaks secret detection only
+```
+
+**Never call tool binaries (e.g., `golangci-lint`, `pytest`, `eslint`, `semgrep`) directly.** Always use the Makefile targets (`make lint`, `make test`, `make sast`, or the per-tool SAST targets above), which invoke the [pipelines repository](https://github.com/rios0rios0/pipelines) scripts to load the correct configuration before running each tool.
 
 ## SAST Toolchain
 

--- a/Life-Cycle/CI-&-CD.md
+++ b/Life-Cycle/CI-&-CD.md
@@ -31,7 +31,7 @@ make test    # Run the full test suite
 make sast    # Run the complete SAST security suite
 ```
 
-**Never invoke linters, test runners, or security tools directly.** Always use the Makefile targets to ensure consistency with CI.
+**Never call tool binaries (e.g., `golangci-lint`, `pytest`, `eslint`, `semgrep`) directly.** Always use the Makefile targets (`make lint`, `make test`, `make sast`), which invoke the [pipelines repository](https://github.com/rios0rios0/pipelines) scripts to load the correct configuration before running each tool.
 
 ## SAST Toolchain
 


### PR DESCRIPTION
The rules previously said "Never invoke linters, test runners, or
security tools directly" which was ambiguous and could be read as also
prohibiting make targets. Updated to specifically prohibit calling tool
binaries directly (e.g., golangci-lint, pytest, eslint, semgrep) and
clarify that the pipelines repository scripts load the correct
configuration before running each tool.

Also added allow rules for individual SAST make targets (make semgrep,
make trivy, make hadolint, make gitleaks) and updated their forbidden-
binary justifications to reference the correct per-tool make target
instead of the generic make sast.
