### PR TITLE
fix(ci): added write permissions for AI rules generation workflow

### DIFF
--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/generate-ai-rules.yaml'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   generate:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
## Summary
- Added permissions: contents: write to the Generate AI Rules workflow so the GITHUB_TOKEN has push access
- Fixes HTTP 403 error (Permission to rios0rios0/guide.git denied to github-actions[bot]) during the git push step

## Test plan
- [ ] Trigger the Generate AI Rules workflow via workflow_dispatch and verify the git push step succeeds
- [ ] Verify the workflow still generates and commits AI rule files correctly