### PR TITLE
feat(commands): added sync-repos claude command

### DIFF
--- a/.ai/claude/commands/sync-repos.md
+++ b/.ai/claude/commands/sync-repos.md
@@ -1,0 +1,21 @@
+Sync all git repositories under `$HOME/Development`. For each repo at depth 2 (`<provider>/<org-or-user>/<repo>`):
+
+1. If the repo has uncommitted changes (staged, unstaged, or untracked), create a WIP branch (`wip/auto-stash-<timestamp>`) and commit all changes with message `wip: auto-stash uncommitted changes`.
+2. Checkout the default branch (detected via `git symbolic-ref refs/remotes/origin/HEAD`, fallback to `main`).
+3. Run `git fetch --all --prune` and `git pull --rebase`.
+4. If pull/rebase fails, abort the rebase and restore the previous branch.
+5. Restore the original branch (or WIP branch if changes were stashed).
+
+Run this by executing the shell function:
+
+```bash
+source ~/.scripts/linux-engineering-git-sync-repos.sh && git-sync-repos
+```
+
+If the user provides a specific subdirectory (e.g. `dev.azure.com/ZestSecurity`), pass it as argument:
+
+```bash
+source ~/.scripts/linux-engineering-git-sync-repos.sh && git-sync-repos "$HOME/Development/dev.azure.com/ZestSecurity"
+```
+
+Print the summary at the end showing total repos, synced, WIP commits, and failures.

--- a/install-rules.sh
+++ b/install-rules.sh
@@ -74,7 +74,7 @@ done
 echo ""
 
 # Claude Code commands (.claude/commands/*.md)
-COMMAND_NAMES="scaffold-go-project scaffold-frontend-project scaffold-python-package fix-guardrails"
+COMMAND_NAMES="scaffold-go-project scaffold-frontend-project scaffold-python-package fix-guardrails sync-repos"
 echo "Claude Code commands:"
 for name in $COMMAND_NAMES; do
   download_file "${BASE_URL}/.ai/claude/commands/${name}.md" "${TARGET_DIR}/.claude/commands/${name}.md"


### PR DESCRIPTION
## Summary

- Added `.ai/claude/commands/sync-repos.md` — a Claude command that syncs all git repositories under `$HOME/Development` by stashing uncommitted changes to WIP branches and pulling the default branch with rebase.
- Updated `install-rules.sh` to include `sync-repos` in the `COMMAND_NAMES` list so it gets installed alongside other commands.

## What the command does

For each repo at depth 2 (`<provider>/<org-or-user>/<repo>`):
1. If uncommitted changes exist, creates a `wip/auto-stash-<timestamp>` branch and commits them
2. Checks out the default branch and runs `git fetch --all --prune && git pull --rebase`
3. On failure, aborts the rebase and restores the previous branch
4. Prints a summary (total, synced, WIP commits, failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)