### PR TITLE
feat(ai-rules): added Copilot generation, external agent fetch, and AI workflows cookbook

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,9 +31,10 @@ Syncs documentation to GitHub Wiki:
 - Expected build time: ~1 second
 
 #### generate-ai-rules (Go 1.24.7)
-Generates AI assistant rule files in `.ai/`:
+Generates AI assistant rule files in `.ai/` for Claude Code, Cursor, Codex, and GitHub Copilot. Also fetches external agents from configured repositories.
 - Build location: `.github/workflows/generate-ai-rules/`
 - Build command: `go build -o generate-ai-rules ./...`
+- Run with external sources: `./generate-ai-rules -external-config external-sources.yaml`
 - Expected build time: ~1 second
 
 **NEVER CANCEL BUILD COMMANDS** - Even though builds are fast (~1s), set timeouts of 30+ seconds.
@@ -140,10 +141,11 @@ Use `install-rules.sh` to distribute the generated AI rule files (downloaded fro
 │   ├── update-wiki.yml               # Syncs docs to GitHub Wiki (Go 1.26.0)
 │   ├── generate-ai-rules.yaml        # Generates .ai/ on 'generated' branch (Go 1.24.7)
 │   ├── generate-ai-rules/            # Go tool + static assets
-│   │   ├── agents/                   # Claude Code agent source files (6 agents)
+│   │   ├── agents/                   # Claude Code agent source files (6 static agents)
 │   │   ├── commands/                 # Claude Code command source files (5 commands)
 │   │   ├── skills/                   # Cursor skill source files (4 skills)
-│   │   └── *.go                      # Go tool (config, parser, formatter)
+│   │   ├── external-sources.yaml     # Config for fetching agents from external repos
+│   │   └── *.go                      # Go tool (config, parser, formatter, external)
 │   └── sync-docs.yaml                # Validates TOC sync on PRs
 ├── Agile-&-Culture/                  # Agile methodology guides
 │   └── PDCA.md                       # PDCA cycle methodology
@@ -169,8 +171,8 @@ Use `install-rules.sh` to distribute the generated AI rule files (downloaded fro
 - **Code style references**: `Code-Style/<language>/` directories
 - **Setup guides**: `Cookbooks/Tools-&-Setup/`
 - **CI/CD information**: `Life-Cycle/CI-&-CD.md`
-- **AI rules**: `generated` branch (`.ai/` directory, auto-generated from docs)
-- **AI rule sources**: `.github/workflows/generate-ai-rules/agents/`, `commands/`, `skills/`
+- **AI rules**: `generated` branch (`.ai/` directory, auto-generated from docs + external sources)
+- **AI rule sources**: `.github/workflows/generate-ai-rules/agents/`, `commands/`, `skills/`, `external-sources.yaml`
 
 ### Build System Details
 ```bash
@@ -208,8 +210,8 @@ bash .github/workflows/sync-docs/check-toc-sync.sh
 ### Repository Characteristics
 - **Type**: Documentation repository (not traditional software)
 - **Primary content**: 79+ Markdown files across 25+ directories
-- **Build output**: GitHub Wiki synchronization + `.ai/` rule files (on `generated` branch)
-- **Dependencies**: Go 1.26.0 for update-wiki; Go 1.24.7 for generate-ai-rules
+- **Build output**: GitHub Wiki synchronization + `.ai/` rule files for Claude Code, Cursor, Codex, and GitHub Copilot (on `generated` branch)
+- **Dependencies**: Go 1.26.0 for update-wiki; Go 1.24.7 for generate-ai-rules (+ gopkg.in/yaml.v3 for external sources)
 - **Tests**: Both Go modules include test files (`*_test.go`)
 
 ### Navigation File Sync Requirement

--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -11,6 +11,7 @@ on:
       - 'Cookbooks/Mapper-Design-Pattern.md'
       - 'Cookbooks/Forking-Technique.md'
       - 'Cookbooks/Bulk-Operations.md'
+      - 'Cookbooks/AI-Assisted-Workflows.md'
       - '.github/workflows/generate-ai-rules/**'
       - '.github/workflows/generate-ai-rules.yaml'
   workflow_dispatch:
@@ -41,7 +42,9 @@ jobs:
           go build -o generate-ai-rules ./...
 
       - name: 'Generate AI Rule Files'
-        run: './${{ env.PROJECT_PATH }}/generate-ai-rules'
+        run: |
+          ./${{ env.PROJECT_PATH }}/generate-ai-rules \
+            -external-config ${{ env.PROJECT_PATH }}/external-sources.yaml
 
       - name: 'Publish Generated Files to generated branch'
         run: |
@@ -70,8 +73,16 @@ jobs:
           rm -rf .ai
           cp -r /tmp/generated-ai .ai
           rm -rf .ai/claude/agents && cp -r /tmp/generated-agents .ai/claude/agents
+          # Merge external agents (fetched during generation) into the static agents directory
+          if [ -d /tmp/generated-ai/.ai/claude/agents ]; then
+            cp -r /tmp/generated-ai/.ai/claude/agents/* .ai/claude/agents/ 2>/dev/null || true
+          fi
           rm -rf .ai/claude/commands && cp -r /tmp/generated-commands .ai/claude/commands
           rm -rf .ai/cursor/skills && cp -r /tmp/generated-skills .ai/cursor/skills
+          # Copy Copilot instructions
+          if [ -d /tmp/generated-ai/.ai/copilot ]; then
+            rm -rf .ai/copilot && cp -r /tmp/generated-ai/.ai/copilot .ai/copilot
+          fi
           cp /tmp/generated-install install-rules.sh
           git add .ai/ install-rules.sh
 

--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -74,15 +74,11 @@ jobs:
           cp -r /tmp/generated-ai .ai
           rm -rf .ai/claude/agents && cp -r /tmp/generated-agents .ai/claude/agents
           # Merge external agents (fetched during generation) into the static agents directory
-          if [ -d /tmp/generated-ai/.ai/claude/agents ]; then
-            cp -r /tmp/generated-ai/.ai/claude/agents/* .ai/claude/agents/ 2>/dev/null || true
+          if [ -d /tmp/generated-ai/claude/agents ]; then
+            cp -r /tmp/generated-ai/claude/agents/* .ai/claude/agents/ 2>/dev/null || true
           fi
           rm -rf .ai/claude/commands && cp -r /tmp/generated-commands .ai/claude/commands
           rm -rf .ai/cursor/skills && cp -r /tmp/generated-skills .ai/cursor/skills
-          # Copy Copilot instructions
-          if [ -d /tmp/generated-ai/.ai/copilot ]; then
-            rm -rf .ai/copilot && cp -r /tmp/generated-ai/.ai/copilot .ai/copilot
-          fi
           cp /tmp/generated-install install-rules.sh
           git add .ai/ install-rules.sh
 

--- a/.github/workflows/generate-ai-rules/external-sources.yaml
+++ b/.github/workflows/generate-ai-rules/external-sources.yaml
@@ -1,0 +1,14 @@
+# External sources for fetching agents and commands from other GitHub repositories.
+# The generate-ai-rules tool downloads these artifacts and includes them in the generated .ai/ directory.
+
+sources:
+  - repo: 'wshobson/agents'
+    branch: 'main'
+    agents:
+      - source: 'plugins/code-documentation/agents/documentation-writer.md'
+        target: 'documentation-writer.md'
+      - source: 'plugins/tdd-workflows/agents/tdd-coach.md'
+        target: 'tdd-coach.md'
+      - source: 'plugins/cicd-automation/agents/cicd-engineer.md'
+        target: 'cicd-engineer.md'
+    commands: []

--- a/.github/workflows/generate-ai-rules/external.go
+++ b/.github/workflows/generate-ai-rules/external.go
@@ -106,6 +106,11 @@ func fetchExternalSources(configPath, outputDir string) int {
 
 // fetchArtifact downloads a single artifact from a GitHub repo and writes it to the output directory.
 func fetchArtifact(repo, branch string, artifact ExternalArtifact, outputDir, artifactType string) error {
+	target := filepath.Base(artifact.Target)
+	if target == "." || target == ".." || target != artifact.Target {
+		return fmt.Errorf("invalid artifact target %q: must be a plain filename without path separators", artifact.Target)
+	}
+
 	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s", repo, branch, artifact.Source)
 
 	body, err := httpGet(url)
@@ -118,7 +123,7 @@ func fetchArtifact(repo, branch string, artifact ExternalArtifact, outputDir, ar
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
 
-	path := filepath.Join(dir, artifact.Target)
+	path := filepath.Join(dir, target)
 	if err := os.WriteFile(path, body, 0644); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
@@ -142,14 +147,16 @@ func httpGet(url string) ([]byte, error) {
 			lastErr = err
 			continue
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
 			lastErr = fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
 			continue
 		}
 
 		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("reading response body: %w", err)
 			continue

--- a/.github/workflows/generate-ai-rules/external.go
+++ b/.github/workflows/generate-ai-rules/external.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	logger "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+// ExternalConfig holds the list of external sources to fetch artifacts from.
+type ExternalConfig struct {
+	Sources []ExternalSource `yaml:"sources"`
+}
+
+// ExternalSource defines a single external GitHub repository and the artifacts to fetch.
+type ExternalSource struct {
+	Repo     string             `yaml:"repo"`
+	Branch   string             `yaml:"branch"`
+	Agents   []ExternalArtifact `yaml:"agents"`
+	Commands []ExternalArtifact `yaml:"commands"`
+}
+
+// ExternalArtifact maps a source file path in an external repo to a target filename.
+type ExternalArtifact struct {
+	Source string `yaml:"source"`
+	Target string `yaml:"target"`
+}
+
+// httpClient is the shared HTTP client for external fetches.
+var httpClient = &http.Client{Timeout: 15 * time.Second}
+
+// loadExternalConfig reads and parses the external sources YAML configuration file.
+func loadExternalConfig(path string) (*ExternalConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading external config %s: %w", path, err)
+	}
+
+	var config ExternalConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("parsing external config %s: %w", path, err)
+	}
+
+	return &config, nil
+}
+
+// fetchExternalSources loads the config and fetches all external artifacts into the output directory.
+func fetchExternalSources(configPath, outputDir string) int {
+	config, err := loadExternalConfig(configPath)
+	if err != nil {
+		logger.WithFields(logger.Fields{
+			"config": configPath,
+			"error":  err.Error(),
+		}).Error("failed to load external sources config")
+		return 1
+	}
+
+	var errorCount int
+	var fetchedCount int
+
+	for _, source := range config.Sources {
+		branch := source.Branch
+		if branch == "" {
+			branch = "main"
+		}
+
+		for _, agent := range source.Agents {
+			if err := fetchArtifact(source.Repo, branch, agent, outputDir, "agents"); err != nil {
+				logger.WithFields(logger.Fields{
+					"repo":   source.Repo,
+					"source": agent.Source,
+					"error":  err.Error(),
+				}).Error("failed to fetch external agent")
+				errorCount++
+			} else {
+				fetchedCount++
+			}
+		}
+
+		for _, cmd := range source.Commands {
+			if err := fetchArtifact(source.Repo, branch, cmd, outputDir, "commands"); err != nil {
+				logger.WithFields(logger.Fields{
+					"repo":   source.Repo,
+					"source": cmd.Source,
+					"error":  err.Error(),
+				}).Error("failed to fetch external command")
+				errorCount++
+			} else {
+				fetchedCount++
+			}
+		}
+	}
+
+	logger.WithFields(logger.Fields{
+		"fetched": fetchedCount,
+		"errors":  errorCount,
+	}).Info("completed fetching external sources")
+
+	return errorCount
+}
+
+// fetchArtifact downloads a single artifact from a GitHub repo and writes it to the output directory.
+func fetchArtifact(repo, branch string, artifact ExternalArtifact, outputDir, artifactType string) error {
+	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s", repo, branch, artifact.Source)
+
+	body, err := httpGet(url)
+	if err != nil {
+		return fmt.Errorf("fetching %s: %w", url, err)
+	}
+
+	dir := filepath.Join(outputDir, ".ai", "claude", artifactType)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	path := filepath.Join(dir, artifact.Target)
+	if err := os.WriteFile(path, body, 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+
+	logger.WithFields(logger.Fields{
+		"repo":   repo,
+		"source": artifact.Source,
+		"target": path,
+		"bytes":  len(body),
+	}).Debug("fetched external artifact")
+
+	return nil
+}
+
+// httpGet performs an HTTP GET with one retry on failure.
+func httpGet(url string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, err := httpClient.Get(url)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			lastErr = fmt.Errorf("reading response body: %w", err)
+			continue
+		}
+		return body, nil
+	}
+	return nil, lastErr
+}

--- a/.github/workflows/generate-ai-rules/external_test.go
+++ b/.github/workflows/generate-ai-rules/external_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadExternalConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		expectErr   bool
+		expectCount int
+	}{
+		{
+			name: "valid config with one source",
+			content: `sources:
+  - repo: 'example/repo'
+    branch: 'main'
+    agents:
+      - source: 'plugins/foo/agents/bar.md'
+        target: 'bar.md'
+    commands:
+      - source: 'plugins/foo/commands/baz.md'
+        target: 'baz.md'
+`,
+			expectCount: 1,
+		},
+		{
+			name:        "empty config",
+			content:     "sources: []\n",
+			expectCount: 0,
+		},
+		{
+			name:      "invalid yaml",
+			content:   "{{invalid",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			os.WriteFile(configPath, []byte(tt.content), 0644)
+
+			// when
+			config, err := loadExternalConfig(configPath)
+
+			// then
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadExternalConfig() error: %v", err)
+			}
+			if len(config.Sources) != tt.expectCount {
+				t.Errorf("expected %d sources, got %d", tt.expectCount, len(config.Sources))
+			}
+		})
+	}
+}
+
+func TestLoadExternalConfigFileNotFound(t *testing.T) {
+	// given
+	path := "/nonexistent/config.yaml"
+
+	// when
+	_, err := loadExternalConfig(path)
+
+	// then
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestFetchArtifact(t *testing.T) {
+	// given
+	agentContent := "---\nname: test-agent\n---\n\nYou are a test agent.\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/agents/test.md") {
+			w.Write([]byte(agentContent))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	// override httpClient to point at test server
+	originalClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = originalClient }()
+
+	tmpDir := t.TempDir()
+	artifact := ExternalArtifact{
+		Source: "agents/test.md",
+		Target: "test-agent.md",
+	}
+
+	// construct a URL that the test server will serve
+	// We need to use the server URL as the "repo" base
+	url := server.URL + "/" + artifact.Source
+
+	// when - directly test httpGet and file writing
+	body, err := httpGet(url)
+	if err != nil {
+		t.Fatalf("httpGet() error: %v", err)
+	}
+
+	dir := filepath.Join(tmpDir, ".ai", "claude", "agents")
+	os.MkdirAll(dir, 0755)
+	path := filepath.Join(dir, artifact.Target)
+	os.WriteFile(path, body, 0644)
+
+	// then
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if string(data) != agentContent {
+		t.Errorf("file content\n  got:  %q\n  want: %q", string(data), agentContent)
+	}
+}
+
+func TestHttpGetRetry(t *testing.T) {
+	// given
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			http.Error(w, "temporary error", http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	originalClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = originalClient }()
+
+	// when
+	body, err := httpGet(server.URL + "/test")
+
+	// then
+	if err != nil {
+		t.Fatalf("httpGet() should succeed on retry, got error: %v", err)
+	}
+	if string(body) != "success" {
+		t.Errorf("expected 'success', got %q", string(body))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (1 fail + 1 success), got %d", callCount)
+	}
+}
+
+func TestHttpGetAllFail(t *testing.T) {
+	// given
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "always fail", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	originalClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = originalClient }()
+
+	// when
+	_, err := httpGet(server.URL + "/test")
+
+	// then
+	if err == nil {
+		t.Fatal("expected error when all retries fail")
+	}
+}
+
+func TestFetchExternalSourcesEmptyConfig(t *testing.T) {
+	// given
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	os.WriteFile(configPath, []byte("sources: []\n"), 0644)
+	outputDir := t.TempDir()
+
+	// when
+	errorCount := fetchExternalSources(configPath, outputDir)
+
+	// then
+	if errorCount != 0 {
+		t.Errorf("expected 0 errors for empty config, got %d", errorCount)
+	}
+}

--- a/.github/workflows/generate-ai-rules/external_test.go
+++ b/.github/workflows/generate-ai-rules/external_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -8,6 +9,17 @@ import (
 	"strings"
 	"testing"
 )
+
+// redirectTransport rewrites all requests to point at the given test server.
+type redirectTransport struct {
+	serverURL string
+}
+
+func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(rt.serverURL, "http://")
+	return http.DefaultTransport.RoundTrip(req)
+}
 
 func TestLoadExternalConfig(t *testing.T) {
 	tests := []struct {
@@ -179,6 +191,68 @@ func TestHttpGetAllFail(t *testing.T) {
 	// then
 	if err == nil {
 		t.Fatal("expected error when all retries fail")
+	}
+}
+
+func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
+	// given
+	agentContent := "You are a test agent.\n"
+	commandContent := "You are a test command.\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/agents/foo.md"):
+			w.Write([]byte(agentContent))
+		case strings.HasSuffix(r.URL.Path, "/commands/bar.md"):
+			w.Write([]byte(commandContent))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	originalClient := httpClient
+	httpClient = &http.Client{Transport: &redirectTransport{serverURL: server.URL}}
+	defer func() { httpClient = originalClient }()
+
+	outputDir := t.TempDir()
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.yaml")
+	configContent := fmt.Sprintf(`sources:
+  - repo: 'test/repo'
+    branch: 'main'
+    agents:
+      - source: 'agents/foo.md'
+        target: 'foo-agent.md'
+    commands:
+      - source: 'commands/bar.md'
+        target: 'bar-command.md'
+`)
+	os.WriteFile(configPath, []byte(configContent), 0644)
+
+	// when
+	errorCount := fetchExternalSources(configPath, outputDir)
+
+	// then
+	if errorCount != 0 {
+		t.Errorf("expected 0 errors, got %d", errorCount)
+	}
+
+	agentPath := filepath.Join(outputDir, ".ai", "claude", "agents", "foo-agent.md")
+	data, err := os.ReadFile(agentPath)
+	if err != nil {
+		t.Fatalf("expected agent file at %s: %v", agentPath, err)
+	}
+	if string(data) != agentContent {
+		t.Errorf("agent content\n  got:  %q\n  want: %q", string(data), agentContent)
+	}
+
+	cmdPath := filepath.Join(outputDir, ".ai", "claude", "commands", "bar-command.md")
+	data, err = os.ReadFile(cmdPath)
+	if err != nil {
+		t.Fatalf("expected command file at %s: %v", cmdPath, err)
+	}
+	if string(data) != commandContent {
+		t.Errorf("command content\n  got:  %q\n  want: %q", string(data), commandContent)
 	}
 }
 

--- a/.github/workflows/generate-ai-rules/formatter.go
+++ b/.github/workflows/generate-ai-rules/formatter.go
@@ -201,12 +201,7 @@ func writeCopilot(outputDir string, group RuleGroup, content string) error {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
 
-	var body string
-	if group.Globs != "" {
-		body = fmt.Sprintf("---\napplyTo: \"%s\"\n---\n\n%s", group.Globs, content)
-	} else {
-		body = content
-	}
+	body := formatCopilotFrontmatter(group.Globs) + content
 
 	path := filepath.Join(dir, group.Name+".instructions.md")
 	if err := os.WriteFile(path, []byte(body), 0644); err != nil {

--- a/.github/workflows/generate-ai-rules/formatter.go
+++ b/.github/workflows/generate-ai-rules/formatter.go
@@ -194,6 +194,31 @@ func writeCodexRules(outputDir string) error {
 	return nil
 }
 
+// writeCopilot writes a rule file in GitHub Copilot format to .ai/copilot/instructions/<name>.instructions.md.
+func writeCopilot(outputDir string, group RuleGroup, content string) error {
+	dir := filepath.Join(outputDir, ".ai", "copilot", "instructions")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	var body string
+	if group.Globs != "" {
+		body = fmt.Sprintf("---\napplyTo: \"%s\"\n---\n\n%s", group.Globs, content)
+	} else {
+		body = content
+	}
+
+	path := filepath.Join(dir, group.Name+".instructions.md")
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		return err
+	}
+	logger.WithFields(logger.Fields{
+		"path":  path,
+		"bytes": len(body),
+	}).Debug("wrote Copilot instruction file")
+	return nil
+}
+
 // formatClaudeFrontmatter returns the frontmatter string for a Claude rule file.
 func formatClaudeFrontmatter(globs string) string {
 	if globs == "" {
@@ -209,4 +234,12 @@ func formatCursorFrontmatter(description string, globs string) string {
 			description, globs)
 	}
 	return fmt.Sprintf("---\ndescription: \"%s\"\nalwaysApply: true\n---\n\n", description)
+}
+
+// formatCopilotFrontmatter returns the frontmatter string for a GitHub Copilot instruction file.
+func formatCopilotFrontmatter(globs string) string {
+	if globs == "" {
+		return ""
+	}
+	return fmt.Sprintf("---\napplyTo: \"%s\"\n---\n\n", globs)
 }

--- a/.github/workflows/generate-ai-rules/formatter_test.go
+++ b/.github/workflows/generate-ai-rules/formatter_test.go
@@ -183,6 +183,90 @@ func TestWriteCursor(t *testing.T) {
 	}
 }
 
+func TestFormatCopilotFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		globs    string
+		expected string
+	}{
+		{
+			name:     "with globs",
+			globs:    "**/*.go",
+			expected: "---\napplyTo: \"**/*.go\"\n---\n\n",
+		},
+		{
+			name:     "without globs",
+			globs:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			globs := tt.globs
+
+			// when
+			result := formatCopilotFrontmatter(globs)
+
+			// then
+			if result != tt.expected {
+				t.Errorf("formatCopilotFrontmatter(%q)\n  got:  %q\n  want: %q", globs, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWriteCopilot(t *testing.T) {
+	tests := []struct {
+		name          string
+		group         RuleGroup
+		content       string
+		expectContent string
+	}{
+		{
+			name: "language rule with applyTo frontmatter",
+			group: RuleGroup{
+				Name:  "golang",
+				Globs: "**/*.go",
+			},
+			content:       "# Go Standards\n\nUse gofmt.\n",
+			expectContent: "---\napplyTo: \"**/*.go\"\n---\n\n# Go Standards\n\nUse gofmt.\n",
+		},
+		{
+			name: "cross-cutting rule without frontmatter",
+			group: RuleGroup{
+				Name: "code-style",
+			},
+			content:       "# Code Style\n\nNaming conventions.\n",
+			expectContent: "# Code Style\n\nNaming conventions.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			tmpDir := t.TempDir()
+
+			// when
+			err := writeCopilot(tmpDir, tt.group, tt.content)
+
+			// then
+			if err != nil {
+				t.Fatalf("writeCopilot() error: %v", err)
+			}
+			path := filepath.Join(tmpDir, ".ai", "copilot", "instructions", tt.group.Name+".instructions.md")
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading output file: %v", err)
+			}
+			if string(data) != tt.expectContent {
+				t.Errorf("file content\n  got:  %q\n  want: %q", string(data), tt.expectContent)
+			}
+		})
+	}
+}
+
 func TestWriteCodex(t *testing.T) {
 	// given
 	tmpDir := t.TempDir()

--- a/.github/workflows/generate-ai-rules/go.mod
+++ b/.github/workflows/generate-ai-rules/go.mod
@@ -2,6 +2,9 @@ module github.com/rios0rios0/guide/generate-ai-rules
 
 go 1.24.7
 
-require github.com/sirupsen/logrus v1.9.4
+require (
+	github.com/sirupsen/logrus v1.9.4
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require golang.org/x/sys v0.41.0 // indirect

--- a/.github/workflows/generate-ai-rules/go.sum
+++ b/.github/workflows/generate-ai-rules/go.sum
@@ -8,5 +8,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.github/workflows/generate-ai-rules/main.go
+++ b/.github/workflows/generate-ai-rules/main.go
@@ -12,6 +12,7 @@ import (
 func main() {
 	sourceDir := flag.String("source", ".", "root directory of the documentation repository")
 	outputDir := flag.String("output", ".", "directory where generated rule files are written")
+	externalConfig := flag.String("external-config", "", "path to external-sources.yaml for fetching agents from external repos")
 	logLevel := flag.String("log-level", "info", "log level: trace, debug, info, warn, error, fatal")
 	flag.Parse()
 
@@ -51,6 +52,11 @@ func main() {
 
 	writeErrors := writeAllRules(*outputDir, groups, contents)
 	totalErrors := errorCount + writeErrors
+
+	if *externalConfig != "" {
+		externalErrors := fetchExternalSources(*externalConfig, *outputDir)
+		totalErrors += externalErrors
+	}
 
 	logger.WithFields(logger.Fields{
 		"groups_processed": len(groups),
@@ -93,7 +99,7 @@ func processGroup(sourceDir string, group RuleGroup) (string, error) {
 // It returns the number of errors encountered during writing.
 func writeAllRules(outputDir string, groups []RuleGroup, contents []string) int {
 	var errorCount int
-	var claudeCount, cursorCount int
+	var claudeCount, cursorCount, copilotCount int
 
 	for i, group := range groups {
 		if contents[i] == "" {
@@ -120,6 +126,15 @@ func writeAllRules(outputDir string, groups []RuleGroup, contents []string) int 
 		} else {
 			cursorCount++
 		}
+		if err := writeCopilot(outputDir, group, contents[i]); err != nil {
+			logger.WithFields(logger.Fields{
+				"group": group.Name,
+				"error": err.Error(),
+			}).Error("failed to write Copilot instruction")
+			errorCount++
+		} else {
+			copilotCount++
+		}
 	}
 
 	if err := writeCodex(outputDir, groups, contents); err != nil {
@@ -137,8 +152,9 @@ func writeAllRules(outputDir string, groups []RuleGroup, contents []string) int 
 	}
 
 	logger.WithFields(logger.Fields{
-		"claude_rules": claudeCount,
-		"cursor_rules": cursorCount,
+		"claude_rules":        claudeCount,
+		"cursor_rules":        cursorCount,
+		"copilot_instructions": copilotCount,
 	}).Info("completed writing rules")
 
 	return errorCount

--- a/.github/workflows/generate-ai-rules/main.go
+++ b/.github/workflows/generate-ai-rules/main.go
@@ -95,7 +95,7 @@ func processGroup(sourceDir string, group RuleGroup) (string, error) {
 	return mergeContents(parts), nil
 }
 
-// writeAllRules writes rule files for all AI assistants (Claude, Cursor, and Codex).
+// writeAllRules writes rule files for all AI assistants (Claude, Cursor, Copilot, and Codex).
 // It returns the number of errors encountered during writing.
 func writeAllRules(outputDir string, groups []RuleGroup, contents []string) int {
 	var errorCount int

--- a/.github/workflows/generate-ai-rules/main_test.go
+++ b/.github/workflows/generate-ai-rules/main_test.go
@@ -142,6 +142,18 @@ func TestEndToEnd(t *testing.T) {
 	assertFileExists(t, cursorGitFlow)
 	assertFileContains(t, cursorGitFlow, "alwaysApply: true")
 
+	// then - verify Copilot instructions under .ai/copilot/instructions/
+	copilotCodeStyle := filepath.Join(outputDir, ".ai", "copilot", "instructions", "code-style.instructions.md")
+	assertFileExists(t, copilotCodeStyle)
+	assertFileContains(t, copilotCodeStyle, "Naming conventions")
+	assertFileNotContains(t, copilotCodeStyle, "applyTo:")
+
+	copilotGitFlow := filepath.Join(outputDir, ".ai", "copilot", "instructions", "git-flow.instructions.md")
+	assertFileExists(t, copilotGitFlow)
+	assertFileContains(t, copilotGitFlow, "feature branches")
+	assertFileContains(t, copilotGitFlow, "Rebase before merge")
+	assertFileNotContains(t, copilotGitFlow, "## References")
+
 	// then - verify Codex AGENTS.md under .ai/codex/
 	agentsFile := filepath.Join(outputDir, ".ai", "codex", "AGENTS.md")
 	assertFileExists(t, agentsFile)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- added GitHub Copilot as a generation target with `.instructions.md` files using `applyTo` frontmatter
+- added AI-Assisted Workflows cookbook page documenting the RPI (Research, Plan, Implement, Review) methodology
+- added dynamic external agent fetch mechanism to pull agents from configured GitHub repositories via `external-sources.yaml`
 - added 5 new Claude Code agents: changelog-enforcer, code-reviewer, git-workflow, security-auditor, and bulk-operations
 - added CHANGELOG.md following the Keep a Changelog standard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ Build times are ~1 second each. Set timeouts to 60+ seconds for safety.
 Markdown files (source of truth)
   ├─→ update-wiki tool ─→ GitHub Wiki (flattened links, absolute image URLs)
   ├─→ generate-ai-rules tool ─→ 'generated' branch (.ai/ directory)
-  │   Static assets (agents, commands, skills) ─→ also copied to 'generated' branch
+  │   ├── Claude Code, Cursor, Codex, GitHub Copilot rule files
+  │   ├── Static assets (agents, commands, skills) ─→ also copied to 'generated' branch
+  │   └── External agents (fetched from external-sources.yaml) ─→ merged into agents/
   └─→ install-rules.sh ─→ downloads from 'generated' branch to ~/.claude/, ~/.cursor/, etc.
 ```
 
@@ -44,7 +46,7 @@ The `.ai/` directory does **not** exist on `main`. It lives only on the `generat
 ### Go Tools
 
 - **`update-wiki`** (`.github/workflows/update-wiki/main.go`): Converts relative markdown links to Wiki-flat format and resolves image paths to GitHub raw content URLs.
-- **`generate-ai-rules`** (`.github/workflows/generate-ai-rules/`): Parses documentation, extracts sections, and formats them into AI-assistant-specific rule files. Has separate `config.go`, `parser.go`, and `formatter.go` modules with corresponding tests.
+- **`generate-ai-rules`** (`.github/workflows/generate-ai-rules/`): Parses documentation, extracts sections, and formats them into AI-assistant-specific rule files. Has separate `config.go`, `parser.go`, `formatter.go`, and `external.go` modules with corresponding tests. Supports fetching agents from external GitHub repos via `external-sources.yaml`.
 
 ### Static Assets (on `main`)
 
@@ -59,9 +61,10 @@ Hand-written files that the workflow copies to the `generated` branch alongside 
 The `generated` branch contains the distributable `.ai/` directory:
 - `claude/rules/` — 14 rule files (`.md`) — auto-generated from docs
 - `claude/commands/` — 5 slash commands — copied from static assets
-- `claude/agents/` — 6 agents — copied from static assets
+- `claude/agents/` — 6 static agents + external agents fetched from configured repos
 - `cursor/rules/` — 14 rule files (`.mdc`) — auto-generated from docs
 - `cursor/skills/` — 4 skills — copied from static assets
+- `copilot/instructions/` — 14 instruction files (`.instructions.md`) — auto-generated with `applyTo` frontmatter
 - `codex/` — `AGENTS.md` and `rules/default.rules` — auto-generated
 
 ## Critical Constraints

--- a/Cookbooks.md
+++ b/Cookbooks.md
@@ -11,3 +11,4 @@ The Cookbooks section provides hands-on recipes and how-to guides that complemen
 - [Historical Repository Cleaner](Cookbooks/Historical-Repository-Cleaner.md) -- Removing secrets from Git history
 - [Mapper Design Pattern](Cookbooks/Mapper-Design-Pattern.md) -- Replacing switch/case with lookup maps
 - [Bulk Operations](Cookbooks/Bulk-Operations.md) -- Applying changes across multiple repositories
+- [AI-Assisted Workflows](Cookbooks/AI-Assisted-Workflows.md) -- Structured AI workflows for complex tasks

--- a/Cookbooks/AI-Assisted-Workflows.md
+++ b/Cookbooks/AI-Assisted-Workflows.md
@@ -1,0 +1,120 @@
+# AI-Assisted Workflows
+
+> **TL;DR:** Use the RPI methodology (Research, Plan, Implement, Review) for complex AI-assisted engineering tasks. Each phase uses a specialized mindset and produces a traceable artifact. Clear context between phases to prevent the AI from conflating investigation with implementation.
+
+## Overview
+
+AI coding assistants excel at well-scoped, straightforward tasks but often fail on complex, multi-file changes. The root cause is that they conflate investigation with implementation -- when asked for code, they generate plausible-sounding solutions without verifying existing patterns, API contracts, or architectural constraints.
+
+The **RPI methodology** (Research, Plan, Implement, Review) solves this by splitting complex work into four sequential phases. Each phase has a distinct objective, produces a traceable artifact, and constrains the AI away from premature action. This is conceptualized as a **type transformation pipeline**:
+
+```
+Uncertainty → Knowledge → Strategy → Working Code → Validated Code
+```
+
+## When to Use RPI
+
+| Use RPI When | Skip RPI When |
+|---|---|
+| Multi-file changes spanning 3+ files | Single-file changes under 50 lines |
+| Introducing a new pattern or API | Typo fixes, log message updates |
+| Integrating with an external dependency | Renaming a variable or function |
+| Requirements are unclear or ambiguous | Adding a test for existing code |
+| Changes touch multiple architectural layers | Updating documentation only |
+
+## The Four Phases
+
+### 1. Research (Uncertainty → Knowledge)
+
+**Objective:** Transform uncertainty into verified knowledge by investigating the codebase, external APIs, and documentation.
+
+**Constraints:**
+- Do NOT write any production code during this phase
+- Focus on verified truth, not plausible assumptions
+- Document findings with traceable evidence (file paths, line numbers, API docs)
+
+**Activities:**
+- Search the codebase for existing implementations and patterns
+- Read external API documentation and verify contracts
+- Identify architectural constraints (which layer should this live in?)
+- Document a single recommended approach per decision point
+
+**Artifact:** `{{YYYY-MM-DD}}-<topic>-research.md` containing findings and recommendations.
+
+### 2. Plan (Knowledge → Strategy)
+
+**Objective:** Convert verified knowledge into an actionable, step-by-step implementation strategy.
+
+**Constraints:**
+- Validate that research artifacts exist before proceeding
+- Reference specific files and line numbers for precision targeting
+- Include validation checkpoints between steps
+
+**Activities:**
+- Break the implementation into ordered tasks with checkboxes
+- Specify which files to create, modify, or delete
+- Define the test strategy (what tests to write, which patterns to follow)
+- Identify potential risks and mitigation steps
+
+**Artifact:** Plan document with implementation tasks, file references, and validation steps.
+
+### 3. Implement (Strategy → Working Code)
+
+**Objective:** Execute the plan tasks sequentially, producing working code with verification at each step.
+
+**Constraints:**
+- Follow the plan strictly -- do not improvise or skip steps
+- Verify each step before proceeding to the next
+- Log all changes for the review phase
+
+**Activities:**
+- Execute plan tasks in order
+- Run tests after each significant change
+- Update the changes log with what was modified and why
+- Pause for intermediate review if the plan specified checkpoints
+
+**Artifact:** Modified code plus `{{YYYY-MM-DD}}-<topic>-changes.md` documenting all changes.
+
+### 4. Review (Working Code → Validated Code)
+
+**Objective:** Validate the implementation against research findings, the plan, and project standards.
+
+**Constraints:**
+- Compare implementation against research findings -- did we implement what we discovered?
+- Check adherence to project conventions (Clean Architecture layers, BDD test structure, naming conventions)
+- Run validation tools (`make lint`, `make test`, `make sast`)
+
+**Activities:**
+- Verify that all plan tasks were completed
+- Run the full validation suite
+- Check for standards compliance (architecture, naming, testing patterns)
+- Identify follow-up work or iteration requirements
+
+**Artifact:** `{{YYYY-MM-DD}}-<topic>-review.md` with validation results and follow-up items.
+
+## Phase Artifacts
+
+| Phase | Artifact | Purpose |
+|---|---|---|
+| Research | `*-research.md` | Verified knowledge and recommendations |
+| Plan | Plan document | Step-by-step implementation strategy |
+| Implement | `*-changes.md` | Change log for traceability |
+| Review | `*-review.md` | Validation results and follow-up items |
+
+Store artifacts in a `.copilot-tracking/` directory (or equivalent) at the project root. These files provide an audit trail and can be referenced in pull request descriptions.
+
+## Integration with Team Standards
+
+The RPI methodology complements the existing development standards:
+
+- **Research phase:** Verify that proposed changes follow Clean Architecture layer separation and dependency direction
+- **Plan phase:** Ensure the test strategy follows BDD patterns (`// given`, `// when`, `// then`) and uses the correct test doubles
+- **Implement phase:** Follow the operations vocabulary (`List`, `Get`, `Insert`, `Update`, `Delete`) and language-specific conventions
+- **Review phase:** Run `make lint`, `make test`, and `make sast` as defined in the CI/CD standards
+
+## Tips for Effective Use
+
+1. **Clear context between phases.** Start a fresh conversation or use `/clear` between phases. Research findings persist in artifact files, not in conversation history.
+2. **One phase at a time.** Do not combine Research and Implementation. The quality of the output depends on the discipline of separating investigation from action.
+3. **Trust the artifacts.** Each phase reads the artifacts from the previous phase. Well-written artifacts make subsequent phases faster and more accurate.
+4. **Iterate when needed.** If the Review phase reveals issues, loop back to the appropriate phase rather than patching in place.

--- a/Home.md
+++ b/Home.md
@@ -56,10 +56,11 @@ And its objective is not to limit the development to a specific form, but to pro
   - [Historical Repository Cleaner](Cookbooks/Historical-Repository-Cleaner.md)
   - [Mapper Design Pattern](Cookbooks/Mapper-Design-Pattern.md)
   - [Bulk Operations](Cookbooks/Bulk-Operations.md)
+  - [AI-Assisted Workflows](Cookbooks/AI-Assisted-Workflows.md)
 
 ## AI Assistant Rules
 
-This repository automatically generates rule files for AI coding assistants (Claude Code, Cursor, Codex) from the documentation. Generated files live on the [`generated`](https://github.com/rios0rios0/guide/tree/generated) branch and can be installed with:
+This repository automatically generates rule files for AI coding assistants (Claude Code, Cursor, Codex, GitHub Copilot) from the documentation. It also fetches curated agents from external repositories. Generated files live on the [`generated`](https://github.com/rios0rios0/guide/tree/generated) branch and can be installed with:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rios0rios0/guide/generated/install-rules.sh | sh

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ A comprehensive software development guide covering agile culture, architecture,
   - [Historical Repository Cleaner](Cookbooks/Historical-Repository-Cleaner.md)
   - [Mapper Design Pattern](Cookbooks/Mapper-Design-Pattern.md)
   - [Bulk Operations](Cookbooks/Bulk-Operations.md)
+  - [AI-Assisted Workflows](Cookbooks/AI-Assisted-Workflows.md)
 
 ## AI Assistant Rules
 
-This repository automatically generates rule files for AI coding assistants (Claude Code, Cursor, Codex) from the documentation. Generated files live on the [`generated`](https://github.com/rios0rios0/guide/tree/generated) branch and can be installed with:
+This repository automatically generates rule files for AI coding assistants (Claude Code, Cursor, Codex, GitHub Copilot) from the documentation. It also fetches curated agents from external repositories. Generated files live on the [`generated`](https://github.com/rios0rios0/guide/tree/generated) branch and can be installed with:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rios0rios0/guide/generated/install-rules.sh | sh

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -51,3 +51,4 @@
   - [Historical Repository Cleaner](Historical-Repository-Cleaner)
   - [Mapper Design Pattern](Mapper-Design-Pattern)
   - [Bulk Operations](Bulk-Operations)
+  - [AI-Assisted Workflows](AI-Assisted-Workflows)

--- a/install-rules.sh
+++ b/install-rules.sh
@@ -86,7 +86,7 @@ done
 echo ""
 
 # Claude Code agents (.claude/agents/*.md)
-AGENT_NAMES="chezmoi changelog-enforcer code-reviewer git-workflow security-auditor bulk-operations"
+AGENT_NAMES="chezmoi changelog-enforcer code-reviewer git-workflow security-auditor bulk-operations documentation-writer tdd-coach cicd-engineer"
 echo "Claude Code agents:"
 for name in $AGENT_NAMES; do
   download_file "${BASE_URL}/.ai/claude/agents/${name}.md" "${TARGET_DIR}/.claude/agents/${name}.md"
@@ -105,6 +105,13 @@ SKILL_NAMES="scaffold-go-project scaffold-frontend-project scaffold-python-packa
 echo "Cursor skills:"
 for name in $SKILL_NAMES; do
   download_file "${BASE_URL}/.ai/cursor/skills/${name}/SKILL.md" "${TARGET_DIR}/.cursor/skills/${name}/SKILL.md"
+done
+echo ""
+
+# GitHub Copilot instructions (.github/instructions/*.instructions.md)
+echo "GitHub Copilot instructions:"
+for name in $RULE_NAMES; do
+  download_file "${BASE_URL}/.ai/copilot/instructions/${name}.instructions.md" "${TARGET_DIR}/.github/instructions/${name}.instructions.md"
 done
 echo ""
 


### PR DESCRIPTION
## Summary

  - Added GitHub Copilot as a fourth generation target,
  producing `.instructions.md` files with `applyTo`
  frontmatter (inspired by [microsoft/hve-core](https://
  github.com/microsoft/hve-core))
  - Added dynamic external agent fetch mechanism via
  `external-sources.yaml`, enabling the pipeline to pull
   curated agents from external GitHub repositories
  (initially configured for
  [wshobson/agents](https://github.com/wshobson/agents))
  - Added AI-Assisted Workflows cookbook page
  documenting the RPI (Research, Plan, Implement,
  Review) methodology for structured AI-assisted
  engineering tasks
  - Updated `install-rules.sh` to distribute Copilot
  instructions and external agents
  - Updated all project documentation (README, Home,
  _Sidebar, CLAUDE.md, copilot-instructions.md,
  CHANGELOG)

  ## Test plan

  - [x] All 38 Go tests pass (`go test ./...` in
  `generate-ai-rules/`)
  - [x] TOC sync validation passes (`check-toc-sync.sh`)
  - [x] Binary builds successfully
  - [x] End-to-end run generates 14 Copilot
  `.instructions.md` files with correct `applyTo`
  frontmatter
  - [ ] Verify `generate-ai-rules.yaml` workflow
  succeeds on merge (generates Copilot output + fetches
  external agents)
  - [ ] Verify `install-rules.sh` downloads Copilot
  instructions to `.github/instructions/`