### PR TITLE
refactor(ai-rules): removed `.ai/` prefix from generated branch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ Syncs documentation to GitHub Wiki:
 - Expected build time: ~1 second
 
 #### generate-ai-rules (Go 1.24.7)
-Generates AI assistant rule files in `.ai/` for Claude Code, Cursor, Codex, and GitHub Copilot. Also fetches external agents from configured repositories.
+Generates AI assistant rule files for Claude Code, Cursor, Codex, and GitHub Copilot. Also fetches external agents from configured repositories.
 - Build location: `.github/workflows/generate-ai-rules/`
 - Build command: `go build -o generate-ai-rules ./...`
 - Run with external sources: `./generate-ai-rules -external-config external-sources.yaml`
@@ -45,7 +45,7 @@ Three workflows are defined under `.github/workflows/`:
 | File | Trigger | Purpose |
 |------|---------|---------|
 | `update-wiki.yml` | Push to `main`, manual dispatch | Syncs docs to GitHub Wiki |
-| `generate-ai-rules.yaml` | Push to `main` (docs paths), manual dispatch | Regenerates `.ai/` on `generated` branch |
+| `generate-ai-rules.yaml` | Push to `main` (docs paths), manual dispatch | Regenerates AI rules on `generated` branch |
 | `sync-docs.yaml` | Pull request (any `.md` change) | Validates TOC sync across README.md, Home.md, _Sidebar.md |
 
 **NEVER CANCEL**: Full workflow takes ~2-3 minutes including setup. Set timeout to 10+ minutes.
@@ -139,7 +139,7 @@ Use `install-rules.sh` to distribute the generated AI rule files (downloaded fro
 ├── .editorconfig                     # Formatting standards
 ├── .github/workflows/                # CI/CD automation
 │   ├── update-wiki.yml               # Syncs docs to GitHub Wiki (Go 1.26.0)
-│   ├── generate-ai-rules.yaml        # Generates .ai/ on 'generated' branch (Go 1.24.7)
+│   ├── generate-ai-rules.yaml        # Generates AI rules on 'generated' branch (Go 1.24.7)
 │   ├── generate-ai-rules/            # Go tool + static assets
 │   │   ├── agents/                   # Claude Code agent source files (6 static agents)
 │   │   ├── commands/                 # Claude Code command source files (5 commands)
@@ -171,7 +171,7 @@ Use `install-rules.sh` to distribute the generated AI rule files (downloaded fro
 - **Code style references**: `Code-Style/<language>/` directories
 - **Setup guides**: `Cookbooks/Tools-&-Setup/`
 - **CI/CD information**: `Life-Cycle/CI-&-CD.md`
-- **AI rules**: `generated` branch (`.ai/` directory, auto-generated from docs + external sources)
+- **AI rules**: `generated` branch (auto-generated from docs + external sources)
 - **AI rule sources**: `.github/workflows/generate-ai-rules/agents/`, `commands/`, `skills/`, `external-sources.yaml`
 
 ### Build System Details
@@ -210,7 +210,7 @@ bash .github/workflows/sync-docs/check-toc-sync.sh
 ### Repository Characteristics
 - **Type**: Documentation repository (not traditional software)
 - **Primary content**: 79+ Markdown files across 25+ directories
-- **Build output**: GitHub Wiki synchronization + `.ai/` rule files for Claude Code, Cursor, Codex, and GitHub Copilot (on `generated` branch)
+- **Build output**: GitHub Wiki synchronization + AI rule files for Claude Code, Cursor, Codex, and GitHub Copilot (on `generated` branch)
 - **Dependencies**: Go 1.26.0 for update-wiki; Go 1.24.7 for generate-ai-rules (+ gopkg.in/yaml.v3 for external sources)
 - **Tests**: Both Go modules include test files (`*_test.go`)
 

--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -73,7 +73,7 @@ jobs:
           fi
 
           # One-time cleanup of legacy .ai/ directory
-          rm -rf .ai
+          git rm -rf .ai 2>/dev/null || true
 
           # Sync generated rules
           rm -rf claude cursor codex copilot

--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -52,14 +52,17 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
           # Save generated output and static assets
-          cp -r .ai /tmp/generated-ai
+          cp -r claude /tmp/generated-claude
+          cp -r cursor /tmp/generated-cursor
+          cp -r codex /tmp/generated-codex
+          cp -r copilot /tmp/generated-copilot
           cp -r $PROJECT_PATH/agents/ /tmp/generated-agents
           cp -r $PROJECT_PATH/commands/ /tmp/generated-commands
           cp -r $PROJECT_PATH/skills/ /tmp/generated-skills
           cp install-rules.sh /tmp/generated-install
 
           # Remove untracked generated files to avoid conflicts when switching branches
-          rm -rf .ai
+          rm -rf claude cursor codex copilot
 
           # Fetch the generated branch if it exists, or create it as orphan
           if git fetch origin generated 2>/dev/null; then
@@ -69,18 +72,29 @@ jobs:
             git rm -rf .
           fi
 
-          # Sync generated rules, static agents/commands/skills, and install script
+          # One-time cleanup of legacy .ai/ directory
           rm -rf .ai
-          cp -r /tmp/generated-ai .ai
-          rm -rf .ai/claude/agents && cp -r /tmp/generated-agents .ai/claude/agents
-          # Merge external agents (fetched during generation) into the static agents directory
-          if [ -d /tmp/generated-ai/claude/agents ]; then
-            cp -r /tmp/generated-ai/claude/agents/* .ai/claude/agents/ 2>/dev/null || true
+
+          # Sync generated rules
+          rm -rf claude cursor codex copilot
+          cp -r /tmp/generated-claude claude
+          cp -r /tmp/generated-cursor cursor
+          cp -r /tmp/generated-codex codex
+          cp -r /tmp/generated-copilot copilot
+
+          # Replace static agents/commands/skills, then merge external agents
+          rm -rf claude/agents && cp -r /tmp/generated-agents claude/agents
+          if [ -d /tmp/generated-claude/agents ]; then
+            cp -r /tmp/generated-claude/agents/* claude/agents/ 2>/dev/null || true
           fi
-          rm -rf .ai/claude/commands && cp -r /tmp/generated-commands .ai/claude/commands
-          rm -rf .ai/cursor/skills && cp -r /tmp/generated-skills .ai/cursor/skills
+          rm -rf claude/commands && cp -r /tmp/generated-commands claude/commands
+          # Merge external commands (fetched during generation) into the static commands directory
+          if [ -d /tmp/generated-claude/commands ]; then
+            cp -r /tmp/generated-claude/commands/* claude/commands/ 2>/dev/null || true
+          fi
+          rm -rf cursor/skills && cp -r /tmp/generated-skills cursor/skills
           cp /tmp/generated-install install-rules.sh
-          git add .ai/ install-rules.sh
+          git add claude/ cursor/ codex/ copilot/ install-rules.sh
 
           # Commit and push (only if there are changes)
           git diff --cached --quiet || git commit -m "chore(ai-rules): regenerated AI rule files"

--- a/.github/workflows/generate-ai-rules/external-sources.yaml
+++ b/.github/workflows/generate-ai-rules/external-sources.yaml
@@ -1,5 +1,5 @@
 # External sources for fetching agents and commands from other GitHub repositories.
-# The generate-ai-rules tool downloads these artifacts and includes them in the generated .ai/ directory.
+# The generate-ai-rules tool downloads these artifacts and includes them in the generated directory.
 
 sources:
   - repo: 'wshobson/agents'

--- a/.github/workflows/generate-ai-rules/external.go
+++ b/.github/workflows/generate-ai-rules/external.go
@@ -118,7 +118,7 @@ func fetchArtifact(repo, branch string, artifact ExternalArtifact, outputDir, ar
 		return fmt.Errorf("fetching %s: %w", url, err)
 	}
 
-	dir := filepath.Join(outputDir, ".ai", "claude", artifactType)
+	dir := filepath.Join(outputDir, "claude", artifactType)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}

--- a/.github/workflows/generate-ai-rules/external_test.go
+++ b/.github/workflows/generate-ai-rules/external_test.go
@@ -127,7 +127,7 @@ func TestFetchArtifact(t *testing.T) {
 		t.Fatalf("httpGet() error: %v", err)
 	}
 
-	dir := filepath.Join(tmpDir, ".ai", "claude", "agents")
+	dir := filepath.Join(tmpDir, "claude", "agents")
 	os.MkdirAll(dir, 0755)
 	path := filepath.Join(dir, artifact.Target)
 	os.WriteFile(path, body, 0644)
@@ -237,7 +237,7 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 		t.Errorf("expected 0 errors, got %d", errorCount)
 	}
 
-	agentPath := filepath.Join(outputDir, ".ai", "claude", "agents", "foo-agent.md")
+	agentPath := filepath.Join(outputDir, "claude", "agents", "foo-agent.md")
 	data, err := os.ReadFile(agentPath)
 	if err != nil {
 		t.Fatalf("expected agent file at %s: %v", agentPath, err)
@@ -246,7 +246,7 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 		t.Errorf("agent content\n  got:  %q\n  want: %q", string(data), agentContent)
 	}
 
-	cmdPath := filepath.Join(outputDir, ".ai", "claude", "commands", "bar-command.md")
+	cmdPath := filepath.Join(outputDir, "claude", "commands", "bar-command.md")
 	data, err = os.ReadFile(cmdPath)
 	if err != nil {
 		t.Fatalf("expected command file at %s: %v", cmdPath, err)

--- a/.github/workflows/generate-ai-rules/formatter.go
+++ b/.github/workflows/generate-ai-rules/formatter.go
@@ -11,9 +11,9 @@ import (
 
 const codexMaxSize = 32 * 1024 // 32 KiB
 
-// writeClaude writes a rule file in Claude Code format to .ai/claude/rules/<name>.md.
+// writeClaude writes a rule file in Claude Code format to claude/rules/<name>.md.
 func writeClaude(outputDir string, group RuleGroup, content string) error {
-	dir := filepath.Join(outputDir, ".ai", "claude", "rules")
+	dir := filepath.Join(outputDir, "claude", "rules")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
@@ -36,9 +36,9 @@ func writeClaude(outputDir string, group RuleGroup, content string) error {
 	return nil
 }
 
-// writeCursor writes a rule file in Cursor format to .ai/cursor/rules/<name>.mdc.
+// writeCursor writes a rule file in Cursor format to cursor/rules/<name>.mdc.
 func writeCursor(outputDir string, group RuleGroup, content string) error {
-	dir := filepath.Join(outputDir, ".ai", "cursor", "rules")
+	dir := filepath.Join(outputDir, "cursor", "rules")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
@@ -82,7 +82,7 @@ func writeCodex(outputDir string, groups []RuleGroup, contents []string) error {
 		}).Warn("AGENTS.md size exceeds Codex limit")
 	}
 
-	dir := filepath.Join(outputDir, ".ai", "codex")
+	dir := filepath.Join(outputDir, "codex")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
@@ -175,9 +175,9 @@ func formatStarlarkList(items []string) string {
 	return "[" + strings.Join(quoted, ", ") + "]"
 }
 
-// writeCodexRules writes the Codex command execution policy file to .ai/codex/rules/default.rules.
+// writeCodexRules writes the Codex command execution policy file to codex/rules/default.rules.
 func writeCodexRules(outputDir string) error {
-	dir := filepath.Join(outputDir, ".ai", "codex", "rules")
+	dir := filepath.Join(outputDir, "codex", "rules")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
@@ -194,9 +194,9 @@ func writeCodexRules(outputDir string) error {
 	return nil
 }
 
-// writeCopilot writes a rule file in GitHub Copilot format to .ai/copilot/instructions/<name>.instructions.md.
+// writeCopilot writes a rule file in GitHub Copilot format to copilot/instructions/<name>.instructions.md.
 func writeCopilot(outputDir string, group RuleGroup, content string) error {
-	dir := filepath.Join(outputDir, ".ai", "copilot", "instructions")
+	dir := filepath.Join(outputDir, "copilot", "instructions")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}

--- a/.github/workflows/generate-ai-rules/formatter_test.go
+++ b/.github/workflows/generate-ai-rules/formatter_test.go
@@ -119,7 +119,7 @@ func TestWriteClaude(t *testing.T) {
 			if err != nil {
 				t.Fatalf("writeClaude() error: %v", err)
 			}
-			path := filepath.Join(tmpDir, ".ai", "claude", "rules", tt.group.Name+".md")
+			path := filepath.Join(tmpDir, "claude", "rules", tt.group.Name+".md")
 			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("reading output file: %v", err)
@@ -171,7 +171,7 @@ func TestWriteCursor(t *testing.T) {
 			if err != nil {
 				t.Fatalf("writeCursor() error: %v", err)
 			}
-			path := filepath.Join(tmpDir, ".ai", "cursor", "rules", tt.group.Name+".mdc")
+			path := filepath.Join(tmpDir, "cursor", "rules", tt.group.Name+".mdc")
 			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("reading output file: %v", err)
@@ -255,7 +255,7 @@ func TestWriteCopilot(t *testing.T) {
 			if err != nil {
 				t.Fatalf("writeCopilot() error: %v", err)
 			}
-			path := filepath.Join(tmpDir, ".ai", "copilot", "instructions", tt.group.Name+".instructions.md")
+			path := filepath.Join(tmpDir, "copilot", "instructions", tt.group.Name+".instructions.md")
 			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("reading output file: %v", err)
@@ -286,7 +286,7 @@ func TestWriteCodex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeCodex() error: %v", err)
 	}
-	path := filepath.Join(tmpDir, ".ai", "codex", "AGENTS.md")
+	path := filepath.Join(tmpDir, "codex", "AGENTS.md")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading AGENTS.md: %v", err)
@@ -376,7 +376,7 @@ func TestWriteCodexRules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeCodexRules() error: %v", err)
 	}
-	path := filepath.Join(tmpDir, ".ai", "codex", "rules", "default.rules")
+	path := filepath.Join(tmpDir, "codex", "rules", "default.rules")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading default.rules: %v", err)

--- a/.github/workflows/generate-ai-rules/main_test.go
+++ b/.github/workflows/generate-ai-rules/main_test.go
@@ -121,47 +121,47 @@ func TestEndToEnd(t *testing.T) {
 		t.Errorf("writeAllRules reported %d errors", errCount)
 	}
 
-	// then - verify Claude rules under .ai/claude/rules/
-	claudeCodeStyle := filepath.Join(outputDir, ".ai", "claude", "rules", "code-style.md")
+	// then - verify Claude rules under claude/rules/
+	claudeCodeStyle := filepath.Join(outputDir, "claude", "rules", "code-style.md")
 	assertFileExists(t, claudeCodeStyle)
 	assertFileContains(t, claudeCodeStyle, "Naming conventions")
 	assertFileNotContains(t, claudeCodeStyle, "---\npaths:")
 
-	claudeGitFlow := filepath.Join(outputDir, ".ai", "claude", "rules", "git-flow.md")
+	claudeGitFlow := filepath.Join(outputDir, "claude", "rules", "git-flow.md")
 	assertFileExists(t, claudeGitFlow)
 	assertFileContains(t, claudeGitFlow, "feature branches")
 	assertFileContains(t, claudeGitFlow, "Rebase before merge")
 	assertFileNotContains(t, claudeGitFlow, "## References")
 
-	// then - verify Cursor rules under .ai/cursor/rules/
-	cursorCodeStyle := filepath.Join(outputDir, ".ai", "cursor", "rules", "code-style.mdc")
+	// then - verify Cursor rules under cursor/rules/
+	cursorCodeStyle := filepath.Join(outputDir, "cursor", "rules", "code-style.mdc")
 	assertFileExists(t, cursorCodeStyle)
 	assertFileContains(t, cursorCodeStyle, "alwaysApply: true")
 
-	cursorGitFlow := filepath.Join(outputDir, ".ai", "cursor", "rules", "git-flow.mdc")
+	cursorGitFlow := filepath.Join(outputDir, "cursor", "rules", "git-flow.mdc")
 	assertFileExists(t, cursorGitFlow)
 	assertFileContains(t, cursorGitFlow, "alwaysApply: true")
 
-	// then - verify Copilot instructions under .ai/copilot/instructions/
-	copilotCodeStyle := filepath.Join(outputDir, ".ai", "copilot", "instructions", "code-style.instructions.md")
+	// then - verify Copilot instructions under copilot/instructions/
+	copilotCodeStyle := filepath.Join(outputDir, "copilot", "instructions", "code-style.instructions.md")
 	assertFileExists(t, copilotCodeStyle)
 	assertFileContains(t, copilotCodeStyle, "Naming conventions")
 	assertFileNotContains(t, copilotCodeStyle, "applyTo:")
 
-	copilotGitFlow := filepath.Join(outputDir, ".ai", "copilot", "instructions", "git-flow.instructions.md")
+	copilotGitFlow := filepath.Join(outputDir, "copilot", "instructions", "git-flow.instructions.md")
 	assertFileExists(t, copilotGitFlow)
 	assertFileContains(t, copilotGitFlow, "feature branches")
 	assertFileContains(t, copilotGitFlow, "Rebase before merge")
 	assertFileNotContains(t, copilotGitFlow, "## References")
 
-	// then - verify Codex AGENTS.md under .ai/codex/
-	agentsFile := filepath.Join(outputDir, ".ai", "codex", "AGENTS.md")
+	// then - verify Codex AGENTS.md under codex/
+	agentsFile := filepath.Join(outputDir, "codex", "AGENTS.md")
 	assertFileExists(t, agentsFile)
 	assertFileContains(t, agentsFile, "Naming conventions")
 	assertFileContains(t, agentsFile, "feature branches")
 
-	// then - verify Codex rules under .ai/codex/rules/
-	codexRulesFile := filepath.Join(outputDir, ".ai", "codex", "rules", "default.rules")
+	// then - verify Codex rules under codex/rules/
+	codexRulesFile := filepath.Join(outputDir, "codex", "rules", "default.rules")
 	assertFileExists(t, codexRulesFile)
 	assertFileContains(t, codexRulesFile, "prefix_rule(")
 	assertFileContains(t, codexRulesFile, "golangci-lint")

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 .github/workflows/generate-ai-rules/generate-ai-rules
 
 # Generated AI rule files (live on the 'generated' branch, not on main)
-.ai/
+claude/
+cursor/
+codex/
+copilot/
 
 # Build artifacts
 /tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added CHANGELOG.md following the Keep a Changelog standard
 
 ### Changed
+- removed `.ai/` prefix directory from the `generated` branch; rule files now live directly at `claude/`, `cursor/`, `codex/`, `copilot/`
 - moved generated `.ai/` directory from `main` branch to a dedicated `generated` branch to eliminate workflow conflicts
 - moved static assets (agents, commands, skills) to `.github/workflows/generate-ai-rules/` as source files on `main`
 - changed `install-rules.sh` to download from the `generated` branch instead of `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A documentation repository that serves as the single source of truth for software engineering standards. It contains 80+ Markdown files organized hierarchically and includes two Go-based automation tools that transform this documentation into GitHub Wiki pages and AI assistant rule files (for Claude Code, Cursor, and Codex).
+A documentation repository that serves as the single source of truth for software engineering standards. It contains 80+ Markdown files organized hierarchically and includes two Go-based automation tools that transform this documentation into GitHub Wiki pages and AI assistant rule files (for Claude Code, Cursor, Codex, and GitHub Copilot).
 
 ## Build, Test, and Validate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ cd .github/workflows/update-wiki
 go build -o update-wiki ./...
 go test ./...
 
-# generate-ai-rules tool (Go 1.24.7) — generates .ai/ rule files from docs
+# generate-ai-rules tool (Go 1.24.7) — generates AI rule files from docs
 cd .github/workflows/generate-ai-rules
 go build -o generate-ai-rules ./...
 go test ./...
@@ -34,14 +34,14 @@ Build times are ~1 second each. Set timeouts to 60+ seconds for safety.
 ```
 Markdown files (source of truth)
   ├─→ update-wiki tool ─→ GitHub Wiki (flattened links, absolute image URLs)
-  ├─→ generate-ai-rules tool ─→ 'generated' branch (.ai/ directory)
+  ├─→ generate-ai-rules tool ─→ 'generated' branch (claude/, cursor/, codex/, copilot/)
   │   ├── Claude Code, Cursor, Codex, GitHub Copilot rule files
   │   ├── Static assets (agents, commands, skills) ─→ also copied to 'generated' branch
   │   └── External agents (fetched from external-sources.yaml) ─→ merged into agents/
   └─→ install-rules.sh ─→ downloads from 'generated' branch to ~/.claude/, ~/.cursor/, etc.
 ```
 
-The `.ai/` directory does **not** exist on `main`. It lives only on the `generated` branch, which is updated automatically by the `generate-ai-rules.yaml` workflow.
+The generated rule directories (`claude/`, `cursor/`, `codex/`, `copilot/`) do **not** exist on `main`. They live only on the `generated` branch, which is updated automatically by the `generate-ai-rules.yaml` workflow.
 
 ### Go Tools
 
@@ -58,7 +58,7 @@ Hand-written files that the workflow copies to the `generated` branch alongside 
 
 ### Generated Output (on `generated` branch)
 
-The `generated` branch contains the distributable `.ai/` directory:
+The `generated` branch contains the distributable rule files:
 - `claude/rules/` — 14 rule files (`.md`) — auto-generated from docs
 - `claude/commands/` — 5 slash commands — copied from static assets
 - `claude/agents/` — 6 static agents + external agents fetched from configured repos
@@ -86,7 +86,7 @@ Documentation files use hyphens (e.g., `Backend-Design.md`). Directories use `&`
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `update-wiki.yml` | Push to `main`, manual | Syncs docs to GitHub Wiki |
-| `generate-ai-rules.yaml` | Push to `main` (doc paths), manual | Regenerates `.ai/` on `generated` branch |
+| `generate-ai-rules.yaml` | Push to `main` (doc paths), manual | Regenerates AI rules on `generated` branch |
 | `sync-docs.yaml` | PR with `.md` changes | Validates TOC sync |
 
 ## Install Script

--- a/install-rules.sh
+++ b/install-rules.sh
@@ -73,7 +73,7 @@ echo ""
 # Claude Code rules (.claude/rules/*.md)
 echo "Claude Code rules:"
 for name in $RULE_NAMES; do
-  download_file "${BASE_URL}/.ai/claude/rules/${name}.md" "${TARGET_DIR}/.claude/rules/${name}.md"
+  download_file "${BASE_URL}/claude/rules/${name}.md" "${TARGET_DIR}/.claude/rules/${name}.md"
 done
 echo ""
 
@@ -81,7 +81,7 @@ echo ""
 COMMAND_NAMES="scaffold-go-project scaffold-frontend-project scaffold-python-package fix-guardrails sync-repos"
 echo "Claude Code commands:"
 for name in $COMMAND_NAMES; do
-  download_file "${BASE_URL}/.ai/claude/commands/${name}.md" "${TARGET_DIR}/.claude/commands/${name}.md"
+  download_file "${BASE_URL}/claude/commands/${name}.md" "${TARGET_DIR}/.claude/commands/${name}.md"
 done
 echo ""
 
@@ -89,14 +89,14 @@ echo ""
 AGENT_NAMES="chezmoi changelog-enforcer code-reviewer git-workflow security-auditor bulk-operations documentation-writer tdd-coach cicd-engineer"
 echo "Claude Code agents:"
 for name in $AGENT_NAMES; do
-  download_file "${BASE_URL}/.ai/claude/agents/${name}.md" "${TARGET_DIR}/.claude/agents/${name}.md"
+  download_file "${BASE_URL}/claude/agents/${name}.md" "${TARGET_DIR}/.claude/agents/${name}.md"
 done
 echo ""
 
 # Cursor rules (.cursor/rules/*.mdc)
 echo "Cursor rules:"
 for name in $RULE_NAMES; do
-  download_file "${BASE_URL}/.ai/cursor/rules/${name}.mdc" "${TARGET_DIR}/.cursor/rules/${name}.mdc"
+  download_file "${BASE_URL}/cursor/rules/${name}.mdc" "${TARGET_DIR}/.cursor/rules/${name}.mdc"
 done
 echo ""
 
@@ -104,25 +104,25 @@ echo ""
 SKILL_NAMES="scaffold-go-project scaffold-frontend-project scaffold-python-package fix-guardrails"
 echo "Cursor skills:"
 for name in $SKILL_NAMES; do
-  download_file "${BASE_URL}/.ai/cursor/skills/${name}/SKILL.md" "${TARGET_DIR}/.cursor/skills/${name}/SKILL.md"
+  download_file "${BASE_URL}/cursor/skills/${name}/SKILL.md" "${TARGET_DIR}/.cursor/skills/${name}/SKILL.md"
 done
 echo ""
 
 # GitHub Copilot instructions (.github/instructions/*.instructions.md)
 echo "GitHub Copilot instructions:"
 for name in $RULE_NAMES; do
-  download_file "${BASE_URL}/.ai/copilot/instructions/${name}.instructions.md" "${TARGET_DIR}/.github/instructions/${name}.instructions.md"
+  download_file "${BASE_URL}/copilot/instructions/${name}.instructions.md" "${TARGET_DIR}/.github/instructions/${name}.instructions.md"
 done
 echo ""
 
 # Codex AGENTS.md
 echo "Codex instructions:"
-download_file "${BASE_URL}/.ai/codex/AGENTS.md" "${TARGET_DIR}/AGENTS.md"
+download_file "${BASE_URL}/codex/AGENTS.md" "${TARGET_DIR}/AGENTS.md"
 echo ""
 
 # Codex rules (.codex/rules/default.rules)
 echo "Codex rules:"
-download_file "${BASE_URL}/.ai/codex/rules/default.rules" "${TARGET_DIR}/.codex/rules/default.rules"
+download_file "${BASE_URL}/codex/rules/default.rules" "${TARGET_DIR}/.codex/rules/default.rules"
 echo ""
 
 echo "Done."


### PR DESCRIPTION
## Summary

- Removed the `.ai/` prefix directory from the `generated` branch output — rule files now live directly at `claude/`, `cursor/`, `codex/`, `copilot/`
- Added missing external commands merge step in the CI workflow (gap from PR #37 Copilot review comment #5)
- Added one-time `rm -rf .ai` cleanup for the legacy directory on the `generated` branch
- Updated all Go code, tests, CI workflow, install script, `.gitignore`, and documentation

## Test plan

- [x] `go build -o generate-ai-rules ./...` succeeds
- [x] `go test ./...` — all 30 tests pass
- [x] `bash .github/workflows/sync-docs/check-toc-sync.sh` — TOC sync validated
- [ ] Trigger `generate-ai-rules.yaml` workflow after merge and verify the `generated` branch has flat directories (no `.ai/`)
- [ ] Run `install-rules.sh` from the updated `generated` branch and verify files download correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)