### PR TITLE
feat(documentation): added CHANGELOG formatting rules for markdown files

### DIFF
--- a/.github/workflows/generate-ai-rules/config.go
+++ b/.github/workflows/generate-ai-rules/config.go
@@ -129,6 +129,14 @@ func ruleGroups() []RuleGroup {
 			},
 		},
 		{
+			Name:        "markdown-formatting",
+			Description: "Markdown formatting rules for changelogs and documentation",
+			Sources: []string{
+				"Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md",
+			},
+			Globs: "**/*.md",
+		},
+		{
 			Name:        "design-patterns",
 			Description: "Design patterns and coding techniques",
 			Sources: []string{

--- a/Home.md
+++ b/Home.md
@@ -20,6 +20,7 @@ And its objective is not to limit the development to a specific form, but to pro
   - [Documentation & Change Control](Life-Cycle/Documentation-&-Change-Control.md)
     - [README Template](Life-Cycle/Documentation-&-Change-Control/README-Template.md)
     - [CONTRIBUTING Template](Life-Cycle/Documentation-&-Change-Control/CONTRIBUTING-Template.md)
+    - [CHANGELOG Formatting](Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md)
 - [Code Style](Code-Style.md)
   - [Language Guide Template](Code-Style/Language-Guide-Template.md)
   - [GoLang](Code-Style/GoLang.md)

--- a/Life-Cycle/Documentation-&-Change-Control.md
+++ b/Life-Cycle/Documentation-&-Change-Control.md
@@ -23,6 +23,7 @@ Every project must contain at minimum:
 
 - [README Template](Documentation-&-Change-Control/README-Template.md) -- copy and customize for new projects
 - [CONTRIBUTING Template](Documentation-&-Change-Control/CONTRIBUTING-Template.md) -- copy and customize for new projects
+- [CHANGELOG Formatting](Documentation-&-Change-Control/CHANGELOG-Formatting.md) -- formatting rules for changelog entries
 
 ## Changelog Standard
 

--- a/Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md
+++ b/Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md
@@ -1,6 +1,6 @@
 # CHANGELOG Formatting
 
-> **TL;DR:** Proper nouns are capitalized, code identifiers use backticks, acronyms are uppercased, versions and library names use backticks.
+> **TL;DR:** Proper nouns are capitalized, code identifiers use backticks, acronyms and protocol names use their official casing, versions and library names use backticks.
 
 ## Rules
 
@@ -32,9 +32,9 @@ Class names, function names, variable names, file names, and any code reference 
 | updated Dockerfile                         | updated `Dockerfile`                           |
 | changed settings.json configuration        | changed `settings.json` configuration          |
 
-### 3. Acronyms -- Always Uppercase
+### 3. Acronyms and Protocol Names -- Use Official Casing
 
-Technical acronyms must always be fully uppercased.
+Technical acronyms must be uppercased. Branded protocol and technology names must use their official casing.
 
 | Wrong  | Correct |
 |--------|---------|

--- a/Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md
+++ b/Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md
@@ -1,0 +1,89 @@
+# CHANGELOG Formatting
+
+> **TL;DR:** Proper nouns are capitalized, code identifiers use backticks, acronyms are uppercased, versions and library names use backticks.
+
+## Rules
+
+### 1. Proper Nouns -- Capitalize Correctly
+
+Product names, company names, and personal names must use their official capitalization.
+
+| Wrong      | Correct    |
+|------------|------------|
+| github     | GitHub     |
+| kubernetes | Kubernetes |
+| docker     | Docker     |
+| terraform  | Terraform  |
+| john doe   | John Doe   |
+| elasticsearch | Elasticsearch |
+| postgresql | PostgreSQL |
+| javascript | JavaScript |
+| typescript | TypeScript |
+
+### 2. Code Identifiers -- Use Backticks
+
+Class names, function names, variable names, file names, and any code reference must be wrapped in backticks.
+
+| Wrong                                      | Correct                                        |
+|--------------------------------------------|------------------------------------------------|
+| added CreateUser command                   | added `CreateUser` command                     |
+| fixed bug in handleRequest function        | fixed bug in `handleRequest` function          |
+| renamed user_id to userId                  | renamed `user_id` to `userId`                  |
+| updated Dockerfile                         | updated `Dockerfile`                           |
+| changed settings.json configuration        | changed `settings.json` configuration          |
+
+### 3. Acronyms -- Always Uppercase
+
+Technical acronyms must always be fully uppercased.
+
+| Wrong  | Correct |
+|--------|---------|
+| http   | HTTP    |
+| api    | API     |
+| sql    | SQL     |
+| css    | CSS     |
+| html   | HTML    |
+| jwt    | JWT     |
+| grpc   | gRPC    |
+| graphql | GraphQL |
+| rest   | REST    |
+| oauth  | OAuth   |
+
+### 4. Versions -- Use Backticks
+
+Version numbers (with or without the `v` prefix) must be wrapped in backticks.
+
+| Wrong                          | Correct                            |
+|--------------------------------|------------------------------------|
+| bumped to v1.2.0               | bumped to `v1.2.0`                 |
+| upgraded from 2.0.0 to 3.0.0  | upgraded from `2.0.0` to `3.0.0`  |
+
+### 5. Library and Package Names -- Use Backticks
+
+Dependency names, package names, and module names must be wrapped in backticks.
+
+| Wrong                              | Correct                                |
+|------------------------------------|----------------------------------------|
+| upgraded lodash to 4.17.21         | upgraded `lodash` to `4.17.21`         |
+| added gin-gonic as HTTP framework  | added `gin-gonic` as HTTP framework    |
+| replaced moment with dayjs         | replaced `moment` with `dayjs`         |
+
+## Examples
+
+**Bad:**
+
+```markdown
+- added createUser endpoint using express framework
+- upgraded golang to v1.23
+- fixed sql injection in handleLogin
+- integrated with github actions for ci/cd
+```
+
+**Good:**
+
+```markdown
+- added `CreateUser` endpoint using `express` framework
+- upgraded Go to `v1.23`
+- fixed SQL injection in `handleLogin`
+- integrated with GitHub Actions for CI/CD
+```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A comprehensive software development guide covering agile culture, architecture,
   - [Documentation & Change Control](Life-Cycle/Documentation-&-Change-Control.md)
     - [README Template](Life-Cycle/Documentation-&-Change-Control/README-Template.md)
     - [CONTRIBUTING Template](Life-Cycle/Documentation-&-Change-Control/CONTRIBUTING-Template.md)
+    - [CHANGELOG Formatting](Life-Cycle/Documentation-&-Change-Control/CHANGELOG-Formatting.md)
 - [Code Style](Code-Style.md)
   - [Language Guide Template](Code-Style/Language-Guide-Template.md)
   - [GoLang](Code-Style/GoLang.md)

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -15,6 +15,7 @@
   - [Documentation & Change Control](Documentation-&-Change-Control)
     - [README Template](README-Template)
     - [CONTRIBUTING Template](CONTRIBUTING-Template)
+    - [CHANGELOG Formatting](CHANGELOG-Formatting)
 - [Code Style](Code-Style)
   - [Language Guide Template](Language-Guide-Template)
   - [GoLang](GoLang)


### PR DESCRIPTION
## Summary

- Added `CHANGELOG-Formatting.md` as a new sub-page under Documentation & Change Control with 5 formatting rules (proper nouns, code identifiers, acronyms, versions, library/package names)
- Added a new `markdown-formatting` rule group in the `generate-ai-rules` config with `**/*.md` glob targeting, so AI assistants enforce these rules whenever editing any markdown file
- Updated TOC across `README.md`, `Home.md`, and `_Sidebar.md`

## Test plan

- [x] TOC sync validation passes (`check-toc-sync.sh`)
- [x] `generate-ai-rules` tool compiles successfully
- [x] Dry run confirms the new rule is generated for all 4 AI assistants (Claude, Cursor, Copilot, Codex) with correct glob frontmatter
- [ ] After merge, verify the `generate-ai-rules.yaml` workflow runs and publishes the new `markdown-formatting` rule to the `generated` branch