### PR TITLE
chore(ci): added Claude Code and Claude Code Review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,0 +1,15 @@
+name: 'Claude Code Review'
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    uses: 'rios0rios0/.github/.github/workflows/claude-code-review.yaml@main'
+    secrets: inherit
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,22 @@
+name: 'Claude Code'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    uses: 'rios0rios0/.github/.github/workflows/claude.yaml@main'
+    secrets: inherit
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'
+      actions: 'read'


### PR DESCRIPTION
Added Claude Code workflows importing reusable workflows from `rios0rios0/.github`, matching other repos (`autobump`, `devforge`, `pipelines`).\n\n### Added\n- `.github/workflows/claude.yaml` — Claude Code on issues/comments/reviews\n- `.github/workflows/claude-code-review.yaml` — Claude Code Review on PRs