### PR TITLE
feat(external-sources): added skills support and integrated everything-claude-code

### DIFF
--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -98,6 +98,11 @@ jobs:
           if [ -d /tmp/generated-cursor/skills ]; then
             cp -r /tmp/generated-cursor/skills/* cursor/skills/ 2>/dev/null || true
           fi
+          # Copy external hooks (no static hooks exist, so no merge needed)
+          if [ -d /tmp/generated-claude/hooks ]; then
+            mkdir -p claude/hooks
+            cp -r /tmp/generated-claude/hooks/* claude/hooks/ 2>/dev/null || true
+          fi
           cp /tmp/generated-install install-rules.sh
           git add claude/ cursor/ codex/ copilot/ install-rules.sh
 

--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -94,6 +94,10 @@ jobs:
             cp -r /tmp/generated-claude/commands/* claude/commands/ 2>/dev/null || true
           fi
           rm -rf cursor/skills && cp -r /tmp/generated-skills cursor/skills
+          # Merge external skills (fetched during generation) into the static skills directory
+          if [ -d /tmp/generated-cursor/skills ]; then
+            cp -r /tmp/generated-cursor/skills/* cursor/skills/ 2>/dev/null || true
+          fi
           cp /tmp/generated-install install-rules.sh
           git add claude/ cursor/ codex/ copilot/ install-rules.sh
 

--- a/.github/workflows/generate-ai-rules/external-sources.yaml
+++ b/.github/workflows/generate-ai-rules/external-sources.yaml
@@ -1,4 +1,4 @@
-# External sources for fetching agents and commands from other GitHub repositories.
+# External sources for fetching agents, commands, and skills from other GitHub repositories.
 # The generate-ai-rules tool downloads these artifacts and includes them in the generated directory.
 
 sources:
@@ -12,3 +12,36 @@ sources:
       - source: 'plugins/cicd-automation/agents/devops-troubleshooter.md'
         target: 'devops-troubleshooter.md'
     commands: []
+    skills: []
+
+  - repo: 'affaan-m/everything-claude-code'
+    branch: 'main'
+    agents:
+      - source: 'agents/architect.md'
+        target: 'architect.md'
+      - source: 'agents/planner.md'
+        target: 'planner.md'
+      - source: 'agents/build-error-resolver.md'
+        target: 'build-error-resolver.md'
+      - source: 'agents/refactor-cleaner.md'
+        target: 'refactor-cleaner.md'
+    commands:
+      - source: 'commands/plan.md'
+        target: 'plan.md'
+      - source: 'commands/verify.md'
+        target: 'verify.md'
+      - source: 'commands/test-coverage.md'
+        target: 'test-coverage.md'
+      - source: 'commands/checkpoint.md'
+        target: 'checkpoint.md'
+    skills:
+      - source: 'skills/tdd-workflow/SKILL.md'
+        target: 'tdd-workflow/SKILL.md'
+      - source: 'skills/api-design/SKILL.md'
+        target: 'api-design/SKILL.md'
+      - source: 'skills/database-migrations/SKILL.md'
+        target: 'database-migrations/SKILL.md'
+      - source: 'skills/architecture-decision-records/SKILL.md'
+        target: 'architecture-decision-records/SKILL.md'
+      - source: 'skills/deployment-patterns/SKILL.md'
+        target: 'deployment-patterns/SKILL.md'

--- a/.github/workflows/generate-ai-rules/external-sources.yaml
+++ b/.github/workflows/generate-ai-rules/external-sources.yaml
@@ -1,7 +1,18 @@
-# External sources for fetching agents, commands, and skills from other GitHub repositories.
+# External sources for fetching agents, commands, skills, and hooks from other GitHub repositories.
 # The generate-ai-rules tool downloads these artifacts and includes them in the generated directory.
+#
+# This file is part of the rios0rios0/guide project (https://github.com/rios0rios0/guide), which
+# serves as the single source of truth for software engineering standards. The generate-ai-rules
+# tool transforms documentation into AI assistant rule files for Claude Code, Cursor, Codex, and
+# GitHub Copilot. External sources listed here complement the guide's own static agents, commands,
+# and skills with community and vendor contributions.
+#
+# Adding a new source: append an entry under 'sources' with the repo, branch, and artifact lists.
+# Supported artifact types: agents, commands, skills (<name>/SKILL.md), hooks.
 
 sources:
+  # https://github.com/wshobson/agents
+  # Multi-agent orchestration system with 112+ specialized agents organized into focused plugins.
   - repo: 'wshobson/agents'
     branch: 'main'
     agents:
@@ -13,7 +24,11 @@ sources:
         target: 'devops-troubleshooter.md'
     commands: []
     skills: []
+    hooks: []
 
+  # https://github.com/affaan-m/everything-claude-code
+  # Agent harness performance optimization system with 28 agents, 125 skills, 60 commands, and
+  # hooks. Anthropic Hackathon winner. Supports 7+ programming languages.
   - repo: 'affaan-m/everything-claude-code'
     branch: 'main'
     agents:
@@ -45,3 +60,18 @@ sources:
         target: 'architecture-decision-records/SKILL.md'
       - source: 'skills/deployment-patterns/SKILL.md'
         target: 'deployment-patterns/SKILL.md'
+    hooks:
+      - source: 'hooks/hooks.json'
+        target: 'hooks.json'
+
+  # https://github.com/microsoft/power-platform-skills
+  # Official Microsoft plugin marketplace for Claude Code / GitHub Copilot providing Power Platform
+  # development plugins with reusable skills, agents, and commands.
+  - repo: 'microsoft/power-platform-skills'
+    branch: 'main'
+    agents:
+      - source: 'plugins/code-apps/agents/code-app-architect.md'
+        target: 'code-app-architect.md'
+    commands: []
+    skills: []
+    hooks: []

--- a/.github/workflows/generate-ai-rules/external.go
+++ b/.github/workflows/generate-ai-rules/external.go
@@ -26,6 +26,7 @@ type ExternalSource struct {
 	Agents   []ExternalArtifact `yaml:"agents"`
 	Commands []ExternalArtifact `yaml:"commands"`
 	Skills   []ExternalArtifact `yaml:"skills"`
+	Hooks    []ExternalArtifact `yaml:"hooks"`
 }
 
 // ExternalArtifact maps a source file path in an external repo to a target filename.
@@ -110,6 +111,19 @@ func fetchExternalSources(configPath, outputDir string) int {
 				fetchedCount++
 			}
 		}
+
+		for _, hook := range source.Hooks {
+			if err := fetchArtifact(source.Repo, branch, hook, outputDir, "hooks"); err != nil {
+				logger.WithFields(logger.Fields{
+					"repo":   source.Repo,
+					"source": hook.Source,
+					"error":  err.Error(),
+				}).Error("failed to fetch external hook")
+				errorCount++
+			} else {
+				fetchedCount++
+			}
+		}
 	}
 
 	logger.WithFields(logger.Fields{
@@ -138,7 +152,7 @@ func validateTarget(target, artifactType string) error {
 	}
 
 	switch artifactType {
-	case "agents", "commands":
+	case "agents", "commands", "hooks":
 		if path.Base(cleaned) != cleaned {
 			return fmt.Errorf("invalid artifact target %q: %s targets must be plain filenames", target, artifactType)
 		}

--- a/.github/workflows/generate-ai-rules/external.go
+++ b/.github/workflows/generate-ai-rules/external.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	logger "github.com/sirupsen/logrus"
@@ -23,6 +24,7 @@ type ExternalSource struct {
 	Branch   string             `yaml:"branch"`
 	Agents   []ExternalArtifact `yaml:"agents"`
 	Commands []ExternalArtifact `yaml:"commands"`
+	Skills   []ExternalArtifact `yaml:"skills"`
 }
 
 // ExternalArtifact maps a source file path in an external repo to a target filename.
@@ -94,6 +96,19 @@ func fetchExternalSources(configPath, outputDir string) int {
 				fetchedCount++
 			}
 		}
+
+		for _, skill := range source.Skills {
+			if err := fetchArtifact(source.Repo, branch, skill, outputDir, "skills"); err != nil {
+				logger.WithFields(logger.Fields{
+					"repo":   source.Repo,
+					"source": skill.Source,
+					"error":  err.Error(),
+				}).Error("failed to fetch external skill")
+				errorCount++
+			} else {
+				fetchedCount++
+			}
+		}
 	}
 
 	logger.WithFields(logger.Fields{
@@ -104,11 +119,48 @@ func fetchExternalSources(configPath, outputDir string) int {
 	return errorCount
 }
 
+// validateTarget checks that the artifact target path is safe for the given artifact type.
+// Agents and commands must be plain filenames. Skills must follow the <name>/SKILL.md pattern.
+func validateTarget(target, artifactType string) error {
+	cleaned := filepath.Clean(target)
+	if filepath.IsAbs(cleaned) {
+		return fmt.Errorf("invalid artifact target %q: must be a relative path", target)
+	}
+	if strings.Contains(cleaned, "..") {
+		return fmt.Errorf("invalid artifact target %q: path traversal not allowed", target)
+	}
+
+	switch artifactType {
+	case "agents", "commands":
+		if filepath.Base(cleaned) != cleaned {
+			return fmt.Errorf("invalid artifact target %q: %s targets must be plain filenames", target, artifactType)
+		}
+	case "skills":
+		parts := strings.Split(cleaned, string(filepath.Separator))
+		if len(parts) != 2 || parts[1] != "SKILL.md" {
+			return fmt.Errorf("invalid artifact target %q: skills targets must follow the <name>/SKILL.md pattern", target)
+		}
+	default:
+		return fmt.Errorf("unknown artifact type %q", artifactType)
+	}
+
+	return nil
+}
+
+// artifactOutputDir returns the directory where the fetched artifact file should be written.
+// Agents and commands go to claude/<type>/, skills go to cursor/skills/<name>/.
+func artifactOutputDir(outputDir, artifactType, target string) string {
+	if artifactType == "skills" {
+		skillName := strings.Split(filepath.Clean(target), string(filepath.Separator))[0]
+		return filepath.Join(outputDir, "cursor", "skills", skillName)
+	}
+	return filepath.Join(outputDir, "claude", artifactType)
+}
+
 // fetchArtifact downloads a single artifact from a GitHub repo and writes it to the output directory.
 func fetchArtifact(repo, branch string, artifact ExternalArtifact, outputDir, artifactType string) error {
-	target := filepath.Base(artifact.Target)
-	if target == "." || target == ".." || target != artifact.Target {
-		return fmt.Errorf("invalid artifact target %q: must be a plain filename without path separators", artifact.Target)
+	if err := validateTarget(artifact.Target, artifactType); err != nil {
+		return err
 	}
 
 	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s", repo, branch, artifact.Source)
@@ -118,12 +170,12 @@ func fetchArtifact(repo, branch string, artifact ExternalArtifact, outputDir, ar
 		return fmt.Errorf("fetching %s: %w", url, err)
 	}
 
-	dir := filepath.Join(outputDir, "claude", artifactType)
+	dir := artifactOutputDir(outputDir, artifactType, artifact.Target)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
 
-	path := filepath.Join(dir, target)
+	path := filepath.Join(dir, filepath.Base(artifact.Target))
 	if err := os.WriteFile(path, body, 0644); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}

--- a/.github/workflows/generate-ai-rules/external.go
+++ b/.github/workflows/generate-ai-rules/external.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -121,9 +122,15 @@ func fetchExternalSources(configPath, outputDir string) int {
 
 // validateTarget checks that the artifact target path is safe for the given artifact type.
 // Agents and commands must be plain filenames. Skills must follow the <name>/SKILL.md pattern.
+// Targets must be canonical (path.Clean(target) == target) to prevent traversal segments like
+// "sub/../foo.md" from being silently normalized. The path package is used instead of
+// filepath because config targets always use forward slashes regardless of OS.
 func validateTarget(target, artifactType string) error {
-	cleaned := filepath.Clean(target)
-	if filepath.IsAbs(cleaned) {
+	cleaned := path.Clean(target)
+	if cleaned != target {
+		return fmt.Errorf("invalid artifact target %q: must be a canonical path (cleaned to %q)", target, cleaned)
+	}
+	if path.IsAbs(cleaned) {
 		return fmt.Errorf("invalid artifact target %q: must be a relative path", target)
 	}
 	if strings.Contains(cleaned, "..") {
@@ -132,11 +139,11 @@ func validateTarget(target, artifactType string) error {
 
 	switch artifactType {
 	case "agents", "commands":
-		if filepath.Base(cleaned) != cleaned {
+		if path.Base(cleaned) != cleaned {
 			return fmt.Errorf("invalid artifact target %q: %s targets must be plain filenames", target, artifactType)
 		}
 	case "skills":
-		parts := strings.Split(cleaned, string(filepath.Separator))
+		parts := strings.Split(cleaned, "/")
 		if len(parts) != 2 || parts[1] != "SKILL.md" {
 			return fmt.Errorf("invalid artifact target %q: skills targets must follow the <name>/SKILL.md pattern", target)
 		}
@@ -149,9 +156,10 @@ func validateTarget(target, artifactType string) error {
 
 // artifactOutputDir returns the directory where the fetched artifact file should be written.
 // Agents and commands go to claude/<type>/, skills go to cursor/skills/<name>/.
+// Uses the path package to split config-style forward-slash paths portably.
 func artifactOutputDir(outputDir, artifactType, target string) string {
 	if artifactType == "skills" {
-		skillName := strings.Split(filepath.Clean(target), string(filepath.Separator))[0]
+		skillName := strings.Split(path.Clean(target), "/")[0]
 		return filepath.Join(outputDir, "cursor", "skills", skillName)
 	}
 	return filepath.Join(outputDir, "claude", artifactType)

--- a/.github/workflows/generate-ai-rules/external_test.go
+++ b/.github/workflows/generate-ai-rules/external_test.go
@@ -48,6 +48,19 @@ func TestLoadExternalConfig(t *testing.T) {
 			expectCount: 0,
 		},
 		{
+			name: "valid config with skills",
+			content: `sources:
+  - repo: 'example/repo'
+    branch: 'main'
+    agents: []
+    commands: []
+    skills:
+      - source: 'skills/tdd-workflow/SKILL.md'
+        target: 'tdd-workflow/SKILL.md'
+`,
+			expectCount: 1,
+		},
+		{
 			name:      "invalid yaml",
 			content:   "{{invalid",
 			expectErr: true,
@@ -198,12 +211,15 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 	// given
 	agentContent := "You are a test agent.\n"
 	commandContent := "You are a test command.\n"
+	skillContent := "---\nname: tdd\n---\n\nTDD workflow skill.\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/agents/foo.md"):
 			w.Write([]byte(agentContent))
 		case strings.HasSuffix(r.URL.Path, "/commands/bar.md"):
 			w.Write([]byte(commandContent))
+		case strings.HasSuffix(r.URL.Path, "/skills/tdd/SKILL.md"):
+			w.Write([]byte(skillContent))
 		default:
 			http.NotFound(w, r)
 		}
@@ -226,6 +242,9 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
     commands:
       - source: 'commands/bar.md'
         target: 'bar-command.md'
+    skills:
+      - source: 'skills/tdd/SKILL.md'
+        target: 'tdd/SKILL.md'
 `)
 	os.WriteFile(configPath, []byte(configContent), 0644)
 
@@ -254,6 +273,15 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 	if string(data) != commandContent {
 		t.Errorf("command content\n  got:  %q\n  want: %q", string(data), commandContent)
 	}
+
+	skillPath := filepath.Join(outputDir, "cursor", "skills", "tdd", "SKILL.md")
+	data, err = os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("expected skill file at %s: %v", skillPath, err)
+	}
+	if string(data) != skillContent {
+		t.Errorf("skill content\n  got:  %q\n  want: %q", string(data), skillContent)
+	}
 }
 
 func TestFetchExternalSourcesEmptyConfig(t *testing.T) {
@@ -269,5 +297,107 @@ func TestFetchExternalSourcesEmptyConfig(t *testing.T) {
 	// then
 	if errorCount != 0 {
 		t.Errorf("expected 0 errors for empty config, got %d", errorCount)
+	}
+}
+
+func TestValidateTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       string
+		artifactType string
+		expectErr    bool
+	}{
+		{"valid agent", "foo.md", "agents", false},
+		{"valid command", "bar.md", "commands", false},
+		{"valid skill", "tdd-workflow/SKILL.md", "skills", false},
+		{"agent with path separator", "sub/foo.md", "agents", true},
+		{"command with path separator", "sub/bar.md", "commands", true},
+		{"skill missing SKILL.md", "tdd-workflow/readme.md", "skills", true},
+		{"skill flat file", "SKILL.md", "skills", true},
+		{"skill too deep", "a/b/SKILL.md", "skills", true},
+		{"path traversal in agent", "../etc/passwd", "agents", true},
+		{"path traversal in skill", "../etc/SKILL.md", "skills", true},
+		{"absolute path", "/tmp/foo.md", "agents", true},
+		{"unknown artifact type", "foo.md", "unknown", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := validateTarget(tt.target, tt.artifactType)
+
+			// then
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error for target %q (%s), got nil", tt.target, tt.artifactType)
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error for target %q (%s): %v", tt.target, tt.artifactType, err)
+			}
+		})
+	}
+}
+
+func TestArtifactOutputDir(t *testing.T) {
+	tests := []struct {
+		name         string
+		artifactType string
+		target       string
+		expected     string
+	}{
+		{"agents", "agents", "foo.md", filepath.Join("/out", "claude", "agents")},
+		{"commands", "commands", "bar.md", filepath.Join("/out", "claude", "commands")},
+		{"skills", "skills", "tdd-workflow/SKILL.md", filepath.Join("/out", "cursor", "skills", "tdd-workflow")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			got := artifactOutputDir("/out", tt.artifactType, tt.target)
+
+			// then
+			if got != tt.expected {
+				t.Errorf("artifactOutputDir(%q, %q) = %q, want %q", tt.artifactType, tt.target, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFetchArtifactSkill(t *testing.T) {
+	// given
+	skillContent := "---\nname: api-design\n---\n\nAPI design skill.\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/skills/api-design/SKILL.md") {
+			w.Write([]byte(skillContent))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	originalClient := httpClient
+	httpClient = &http.Client{Transport: &redirectTransport{serverURL: server.URL}}
+	defer func() { httpClient = originalClient }()
+
+	outputDir := t.TempDir()
+	artifact := ExternalArtifact{
+		Source: "skills/api-design/SKILL.md",
+		Target: "api-design/SKILL.md",
+	}
+
+	// when
+	err := fetchArtifact("test/repo", "main", artifact, outputDir, "skills")
+
+	// then
+	if err != nil {
+		t.Fatalf("fetchArtifact() error: %v", err)
+	}
+
+	skillPath := filepath.Join(outputDir, "cursor", "skills", "api-design", "SKILL.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("expected skill file at %s: %v", skillPath, err)
+	}
+	if string(data) != skillContent {
+		t.Errorf("skill content\n  got:  %q\n  want: %q", string(data), skillContent)
 	}
 }

--- a/.github/workflows/generate-ai-rules/external_test.go
+++ b/.github/workflows/generate-ai-rules/external_test.go
@@ -317,6 +317,9 @@ func TestValidateTarget(t *testing.T) {
 		{"skill too deep", "a/b/SKILL.md", "skills", true},
 		{"path traversal in agent", "../etc/passwd", "agents", true},
 		{"path traversal in skill", "../etc/SKILL.md", "skills", true},
+		{"normalized traversal in agent", "sub/../foo.md", "agents", true},
+		{"normalized traversal in command", "sub/../bar.md", "commands", true},
+		{"normalized traversal in skill", "sub/../tdd-workflow/SKILL.md", "skills", true},
 		{"absolute path", "/tmp/foo.md", "agents", true},
 		{"unknown artifact type", "foo.md", "unknown", true},
 	}

--- a/.github/workflows/generate-ai-rules/external_test.go
+++ b/.github/workflows/generate-ai-rules/external_test.go
@@ -57,6 +57,21 @@ func TestLoadExternalConfig(t *testing.T) {
     skills:
       - source: 'skills/tdd-workflow/SKILL.md'
         target: 'tdd-workflow/SKILL.md'
+    hooks: []
+`,
+			expectCount: 1,
+		},
+		{
+			name: "valid config with hooks",
+			content: `sources:
+  - repo: 'example/repo'
+    branch: 'main'
+    agents: []
+    commands: []
+    skills: []
+    hooks:
+      - source: 'hooks/hooks.json'
+        target: 'hooks.json'
 `,
 			expectCount: 1,
 		},
@@ -212,6 +227,7 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 	agentContent := "You are a test agent.\n"
 	commandContent := "You are a test command.\n"
 	skillContent := "---\nname: tdd\n---\n\nTDD workflow skill.\n"
+	hookContent := "{\"hooks\": {}}\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/agents/foo.md"):
@@ -220,6 +236,8 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 			w.Write([]byte(commandContent))
 		case strings.HasSuffix(r.URL.Path, "/skills/tdd/SKILL.md"):
 			w.Write([]byte(skillContent))
+		case strings.HasSuffix(r.URL.Path, "/hooks/hooks.json"):
+			w.Write([]byte(hookContent))
 		default:
 			http.NotFound(w, r)
 		}
@@ -245,6 +263,9 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
     skills:
       - source: 'skills/tdd/SKILL.md'
         target: 'tdd/SKILL.md'
+    hooks:
+      - source: 'hooks/hooks.json'
+        target: 'hooks.json'
 `)
 	os.WriteFile(configPath, []byte(configContent), 0644)
 
@@ -282,6 +303,15 @@ func TestFetchExternalSourcesWithArtifacts(t *testing.T) {
 	if string(data) != skillContent {
 		t.Errorf("skill content\n  got:  %q\n  want: %q", string(data), skillContent)
 	}
+
+	hookPath := filepath.Join(outputDir, "claude", "hooks", "hooks.json")
+	data, err = os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("expected hook file at %s: %v", hookPath, err)
+	}
+	if string(data) != hookContent {
+		t.Errorf("hook content\n  got:  %q\n  want: %q", string(data), hookContent)
+	}
 }
 
 func TestFetchExternalSourcesEmptyConfig(t *testing.T) {
@@ -310,6 +340,7 @@ func TestValidateTarget(t *testing.T) {
 		{"valid agent", "foo.md", "agents", false},
 		{"valid command", "bar.md", "commands", false},
 		{"valid skill", "tdd-workflow/SKILL.md", "skills", false},
+		{"valid hook", "hooks.json", "hooks", false},
 		{"agent with path separator", "sub/foo.md", "agents", true},
 		{"command with path separator", "sub/bar.md", "commands", true},
 		{"skill missing SKILL.md", "tdd-workflow/readme.md", "skills", true},
@@ -350,6 +381,7 @@ func TestArtifactOutputDir(t *testing.T) {
 		{"agents", "agents", "foo.md", filepath.Join("/out", "claude", "agents")},
 		{"commands", "commands", "bar.md", filepath.Join("/out", "claude", "commands")},
 		{"skills", "skills", "tdd-workflow/SKILL.md", filepath.Join("/out", "cursor", "skills", "tdd-workflow")},
+		{"hooks", "hooks", "hooks.json", filepath.Join("/out", "claude", "hooks")},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Extended the external sources pipeline to support **skills** (directory-based `<name>/SKILL.md` artifacts) in addition to agents and commands
- Added `affaan-m/everything-claude-code` as a new pluggable external source with a curated selection of 4 agents, 4 commands, and 5 skills that complement existing assets
- Added path validation helpers (`validateTarget`, `artifactOutputDir`) to safely route skills to `cursor/skills/` while agents/commands continue going to `claude/`

### Curated ECC artifacts

**Agents:** `architect`, `planner`, `build-error-resolver`, `refactor-cleaner`
**Commands:** `plan`, `verify`, `test-coverage`, `checkpoint`
**Skills:** `tdd-workflow`, `api-design`, `database-migrations`, `architecture-decision-records`, `deployment-patterns`

Artifacts that overlap with existing static assets (`code-reviewer`, `security-reviewer`, `tdd-guide`, `quality-gate`) were intentionally excluded.

## Test plan

- [x] All 45 Go tests pass (`go test ./...` in `generate-ai-rules/`)
- [x] Build succeeds (`go build -o generate-ai-rules ./...`)
- [ ] Verify `generated` branch after workflow run contains new ECC agents in `claude/agents/`, commands in `claude/commands/`, and skills in `cursor/skills/<name>/SKILL.md`
- [ ] Confirm no static assets were overwritten by checking `code-reviewer.md` and `security-auditor.md` remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)