### PR TITLE
feat(install): added fix-ci command, changelog-guard hook, and checksum comparison

### DIFF
--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -60,6 +60,7 @@ jobs:
           cp -r $PROJECT_PATH/agents/ /tmp/generated-agents
           cp -r $PROJECT_PATH/commands/ /tmp/generated-commands
           cp -r $PROJECT_PATH/skills/ /tmp/generated-skills
+          cp -r $PROJECT_PATH/hooks/ /tmp/generated-hooks
           cp install-rules.sh /tmp/generated-install
 
           # Remove untracked generated files to avoid conflicts when switching branches
@@ -98,9 +99,9 @@ jobs:
           if [ -d /tmp/generated-cursor/skills ]; then
             cp -r /tmp/generated-cursor/skills/* cursor/skills/ 2>/dev/null || true
           fi
-          # Copy external hooks (no static hooks exist, so no merge needed)
+          rm -rf claude/hooks && cp -r /tmp/generated-hooks claude/hooks
+          # Merge external hooks (fetched during generation) into the static hooks directory
           if [ -d /tmp/generated-claude/hooks ]; then
-            mkdir -p claude/hooks
             cp -r /tmp/generated-claude/hooks/* claude/hooks/ 2>/dev/null || true
           fi
           cp /tmp/generated-install install-rules.sh

--- a/.github/workflows/generate-ai-rules/commands/fix-ci.md
+++ b/.github/workflows/generate-ai-rules/commands/fix-ci.md
@@ -1,0 +1,159 @@
+Detect the current branch's pull request, retrieve its failing CI workflow logs, fix the root causes, commit, and push. This command auto-detects the PR from the current Git branch, fetches check run statuses, downloads failure logs, classifies each failure, implements fixes, and pushes a single commit.
+
+For commit conventions, refer to the Git Flow rule. For lint verification, refer to the CI/CD rule.
+
+## Pre-flight
+
+### Step 1 -- Verify GitHub CLI authentication
+
+```bash
+gh auth status
+```
+
+If this fails, report the error and stop. The `gh` CLI must be installed and authenticated.
+
+### Step 2 -- Detect repository context
+
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+
+Split the result into `{owner}` and `{repo}`.
+
+### Step 3 -- Auto-detect PR from current branch
+
+```bash
+gh pr view --json number,headRefName -q '.number'
+```
+
+This returns the PR number associated with the current branch. If it fails (no PR exists for the current branch), report: "No pull request found for the current branch. Switch to a branch with an open PR or create one first." and stop.
+
+Store the returned number as `{PR_NUMBER}`. Then ensure the local branch is up to date:
+
+```bash
+git pull --rebase
+```
+
+## Procedure
+
+### Step 4 -- Fetch check run statuses
+
+List all check runs for the PR and identify failures:
+
+```bash
+gh pr checks {PR_NUMBER}
+```
+
+Filter to checks with `fail` status. If no failing checks exist, report "All CI checks are passing on PR #{PR_NUMBER}." and stop.
+
+### Step 5 -- Retrieve failure logs
+
+For each failing check, retrieve the workflow run ID and job ID from the check URL, then download the failed job logs:
+
+```bash
+gh run view {RUN_ID} --job {JOB_ID} --log-failed
+```
+
+If the log output is very large, use `tail -100` to focus on the error section. Extract:
+- The specific error messages and file/line references
+- The tool or stage that failed (e.g., `golangci-lint`, `make test`, `basic-checks`)
+- Whether the failure is in code you can fix or an infrastructure/flaky issue
+
+### Step 6 -- Classify each failure
+
+For each failing check, classify and plan the fix:
+
+| Category | Examples | Action |
+|----------|----------|--------|
+| **Lint errors** | `golangci-lint`, `eslint`, `flake8`, `revive` | Read the referenced files, apply fixes |
+| **Test failures** | `make test`, `go test`, `pytest` | Read failing test and source code, fix the bug or update the test |
+| **Build errors** | `go build`, `npm build`, type errors | Read the referenced files, fix compilation/type errors |
+| **CHANGELOG missing** | `basic-checks`, "CHANGELOG.md was NOT modified" | Add an entry under `[Unreleased]` in `CHANGELOG.md` |
+| **Formatting** | `gofmt`, `prettier`, `black` | Run the formatter on the affected files |
+| **SAST findings** | `semgrep`, `trivy`, `hadolint`, `gitleaks` | Read the finding, fix the security issue or add a justified suppression |
+| **Infrastructure/flaky** | Network timeouts, runner issues, rate limits | Report to user -- cannot fix from code |
+
+### Step 7 -- Implement fixes
+
+For each fixable failure:
+
+1. **Read the file(s)** referenced in the error log
+2. **Apply the fix** using the Edit tool
+3. **Track what was changed** for the commit message
+
+Group related fixes together. Do not make unrelated changes.
+
+### Step 8 -- Verify fixes locally
+
+Run the relevant verification commands based on what failed:
+
+- If lint failed: run `make lint` (or the project's lint command)
+- If tests failed: run `make test` (or the project's test command)
+- If build failed: run `make build` (or the project's build command)
+- If SAST failed: run `make sast` (or the specific SAST tool)
+
+If local verification still fails, iterate on the fix. If the failure cannot be resolved, report it to the user with the error details.
+
+### Step 9 -- Stage changed files
+
+```bash
+git add <file1> <file2> ...
+```
+
+Stage only the specific files that were modified. Never use `git add -A` or `git add .`.
+
+### Step 10 -- Commit
+
+Follow the Git Flow commit convention:
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(ci): resolved CI pipeline failures
+
+- <summary of fix 1>
+- <summary of fix 2>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+If only one fix was made, the bullet list in the body can be omitted. Group all CI fixes into a single commit.
+
+### Step 11 -- Push
+
+```bash
+git push
+```
+
+The branch already tracks the remote. If push fails, report the error and stop.
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| `gh` CLI not available or not authenticated | Report error and stop. |
+| No PR found for the current branch | Report "No pull request found for the current branch." and stop. |
+| All checks passing | Report "All CI checks are passing on PR #{PR_NUMBER}." and stop. |
+| Log download fails | Try alternative: `gh run view {RUN_ID} --log-failed`. If that also fails, report the error. |
+| Infrastructure/flaky failure (not code-related) | Report to user: "The failure in `{check_name}` appears to be an infrastructure issue (network timeout, runner problem, etc.) and cannot be fixed from code. Consider re-running the workflow." |
+| Fix introduces new failures | Iterate on the fix. If unresolvable after 2 attempts, report to user with details. |
+| Multiple workflow runs exist | Use the most recent run. Identify it from `gh pr checks` output. |
+
+## Progress Reporting
+
+After processing all failures, print a summary:
+
+```
+## PR #{PR_NUMBER} CI Fix Summary
+
+| Check | Failure | Action | Status |
+|-------|---------|--------|--------|
+| golangci-lint | gochecknoglobals in clear_history.go | Moved globals into function scope | Fixed |
+| basic-checks | CHANGELOG.md not modified | Added [Unreleased] entry | Fixed |
+| test:all | TestFoo assertion failure | Fixed expected value | Fixed |
+| sast:semgrep | SQL injection finding | Cannot fix -- infrastructure issue | Reported |
+
+Commit: <short-sha>
+Checks fixed: X / Y
+```

--- a/.github/workflows/generate-ai-rules/hooks/changelog-guard.sh
+++ b/.github/workflows/generate-ai-rules/hooks/changelog-guard.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook: blocks git commits that add CHANGELOG entries
+# outside the [Unreleased] section.
+#
+# Input: JSON on stdin with { tool, input: { command } }
+# Output: exit 2 + JSON on stderr to block with a message.
+
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(echo "$INPUT" | jq -r '.input.command // empty')"
+
+# Only check Bash calls that contain "git commit"
+if ! echo "$COMMAND" | grep -q "git commit"; then
+  exit 0
+fi
+
+# Check if CHANGELOG.md is staged
+if ! git diff --cached --name-only 2>/dev/null | grep -q "^CHANGELOG.md$"; then
+  exit 0
+fi
+
+# Get full-context diff so section headers are always visible
+DIFF="$(git diff --cached -U9999 -- CHANGELOG.md 2>/dev/null)"
+
+# Parse the diff to check if additions land in a released section.
+# Strategy: walk the diff hunks. Track which section we're in by looking at
+# context and added lines that match version headers. If we see an added line
+# (starting with +) that isn't a header and we're inside a released section,
+# that's a violation.
+IN_RELEASED=false
+VIOLATION_LINES=""
+
+while IFS= read -r line; do
+  # Skip diff metadata
+  case "$line" in
+    "---"*|"+++"*|"diff "*|"index "*) continue ;;
+  esac
+
+  # Detect section headers from both context and added lines
+  clean="${line#[+ -]}"
+
+  if echo "$clean" | grep -qE '^## \[Unreleased\]'; then
+    IN_RELEASED=false
+    continue
+  fi
+
+  if echo "$clean" | grep -qE '^## \[[0-9]+\.[0-9]+'; then
+    IN_RELEASED=true
+    continue
+  fi
+
+  # Check added lines (not headers) while in a released section
+  if [ "$IN_RELEASED" = true ] && echo "$line" | grep -qE '^\+[^+]'; then
+    content="${line#+}"
+    # Skip blank lines and category headers (### Added, etc.)
+    trimmed="$(echo "$content" | sed 's/^[[:space:]]*//')"
+    if [ -n "$trimmed" ] && ! echo "$trimmed" | grep -qE '^### '; then
+      VIOLATION_LINES="${VIOLATION_LINES}\n  ${trimmed}"
+    fi
+  fi
+done <<< "$DIFF"
+
+if [ -n "$VIOLATION_LINES" ]; then
+  MSG="CHANGELOG entries are being added to an already-released version section. Released sections are immutable. Move these entries under [Unreleased]:${VIOLATION_LINES}"
+  echo '{"decision": "block", "reason": "'"$(echo "$MSG" | sed 's/"/\\"/g' | tr '\n' ' ')"'"}' >&2
+  exit 2
+fi
+
+exit 0

--- a/.github/workflows/generate-ai-rules/hooks/changelog-guard.sh
+++ b/.github/workflows/generate-ai-rules/hooks/changelog-guard.sh
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"decision":"block","reason":"Missing required dependency: jq. Install jq to enable the changelog-guard hook."}' >&2
+  exit 2
+fi
+
 INPUT="$(cat)"
 COMMAND="$(echo "$INPUT" | jq -r '.input.command // empty')"
 
@@ -15,13 +20,22 @@ if ! echo "$COMMAND" | grep -q "git commit"; then
   exit 0
 fi
 
+# Only run repository checks when we're inside a Git work tree.
+# Fail open if Git context is unavailable.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
 # Check if CHANGELOG.md is staged
 if ! git diff --cached --name-only 2>/dev/null | grep -q "^CHANGELOG.md$"; then
   exit 0
 fi
 
-# Get full-context diff so section headers are always visible
-DIFF="$(git diff --cached -U9999 -- CHANGELOG.md 2>/dev/null)"
+# Get full-context diff so section headers are always visible.
+# Avoid aborting under set -e if git diff fails unexpectedly; fail open instead.
+if ! DIFF="$(git diff --cached -U9999 -- CHANGELOG.md 2>/dev/null)"; then
+  exit 0
+fi
 
 # Parse the diff to check if additions land in a released section.
 # Strategy: walk the diff hunks. Track which section we're in by looking at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- added `fix-ci` slash command for auto-detecting failing CI checks, classifying failures, and pushing fixes
+- added `changelog-guard.sh` hook as a static asset to block commits that add CHANGELOG entries outside the `[Unreleased]` section
+- added hooks installation section to `install-rules.sh` so hooks from the `generated` branch are installed alongside rules, commands, and agents
+- added checksum comparison to `install-rules.sh` that detects unchanged files, shows byte-level size differences, and warns whether installing adds or removes content
+
 ## [0.2.0] - 2026-03-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ Markdown files (source of truth)
   ├─→ update-wiki tool ─→ GitHub Wiki (flattened links, absolute image URLs)
   ├─→ generate-ai-rules tool ─→ 'generated' branch (claude/, cursor/, codex/, copilot/)
   │   ├── Claude Code, Cursor, Codex, GitHub Copilot rule files
-  │   ├── Static assets (agents, commands, skills) ─→ also copied to 'generated' branch
-  │   └── External agents (fetched from external-sources.yaml) ─→ merged into agents/
+  │   ├── Static assets (agents, commands, skills, hooks) ─→ also copied to 'generated' branch
+  │   └── External artifacts (fetched from external-sources.yaml) ─→ merged into respective dirs
   └─→ install-rules.sh ─→ downloads from 'generated' branch to ~/.claude/, ~/.cursor/, etc.
 ```
 
@@ -53,15 +53,17 @@ The generated rule directories (`claude/`, `cursor/`, `codex/`, `copilot/`) do *
 Hand-written files that the workflow copies to the `generated` branch alongside auto-generated rules:
 
 - `.github/workflows/generate-ai-rules/agents/` — 7 Claude Code agent files
-- `.github/workflows/generate-ai-rules/commands/` — 5 Claude Code slash commands
-- `.github/workflows/generate-ai-rules/skills/` — 4 Cursor skills
+- `.github/workflows/generate-ai-rules/commands/` — 8 Claude Code slash commands
+- `.github/workflows/generate-ai-rules/skills/` — 5 Cursor skills
+- `.github/workflows/generate-ai-rules/hooks/` — 1 Claude Code hook
 
 ### Generated Output (on `generated` branch)
 
 The `generated` branch contains the distributable rule files:
 - `claude/rules/` — 14 rule files (`.md`) — auto-generated from docs
-- `claude/commands/` — 5 slash commands — copied from static assets
+- `claude/commands/` — 8 slash commands — copied from static assets + external
 - `claude/agents/` — 7 static agents + external agents fetched from configured repos
+- `claude/hooks/` — 1 static hook + external hooks fetched from configured repos
 - `cursor/rules/` — 14 rule files (`.mdc`) — auto-generated from docs
 - `cursor/skills/` — 4 skills — copied from static assets
 - `copilot/instructions/` — 14 instruction files (`.instructions.md`) — auto-generated with `applyTo` frontmatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ The `generated` branch contains the distributable rule files:
 - `claude/agents/` — 7 static agents + external agents fetched from configured repos
 - `claude/hooks/` — 1 static hook + external hooks fetched from configured repos
 - `cursor/rules/` — 14 rule files (`.mdc`) — auto-generated from docs
-- `cursor/skills/` — 4 skills — copied from static assets
+- `cursor/skills/` — 5 skills — copied from static assets
 - `copilot/instructions/` — 14 instruction files (`.instructions.md`) — auto-generated with `applyTo` frontmatter
 - `codex/` — `AGENTS.md` and `rules/default.rules` — auto-generated
 

--- a/install-rules.sh
+++ b/install-rules.sh
@@ -52,7 +52,7 @@ download_file() {
   mkdir -p "$dir"
 
   # Download to a temporary file first
-  tmp="$(mktemp)"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/install-rules.XXXXXX")"
   if ! curl -fsSL -o "$tmp" "$url"; then
     echo "  Warning: failed to download $url" >&2
     rm -f "$tmp"
@@ -62,6 +62,9 @@ download_file() {
   # If the local file does not exist, install directly
   if [ ! -f "$dest" ]; then
     mv "$tmp" "$dest"
+    chmod 644 "$dest"
+    # Ensure hook scripts are executable
+    case "$dest" in *.sh) chmod 755 "$dest" ;; esac
     echo "  Installed (new): $dest"
     return
   fi
@@ -92,6 +95,8 @@ download_file() {
 
   if [ "$OVERWRITE_ALL" = "yes" ]; then
     mv "$tmp" "$dest"
+    chmod 644 "$dest"
+    case "$dest" in *.sh) chmod 755 "$dest" ;; esac
     echo "  Updated: $dest ($size_note)"
     return
   fi
@@ -101,8 +106,8 @@ download_file() {
   printf "    Overwrite? [y/n/a] "
   read -r answer </dev/tty
   case "$answer" in
-    y|Y) mv "$tmp" "$dest"; echo "  Updated: $dest" ;;
-    a|A) OVERWRITE_ALL="yes"; mv "$tmp" "$dest"; echo "  Updated: $dest" ;;
+    y|Y) mv "$tmp" "$dest"; chmod 644 "$dest"; case "$dest" in *.sh) chmod 755 "$dest" ;; esac; echo "  Updated: $dest" ;;
+    a|A) OVERWRITE_ALL="yes"; mv "$tmp" "$dest"; chmod 644 "$dest"; case "$dest" in *.sh) chmod 755 "$dest" ;; esac; echo "  Updated: $dest" ;;
     *)   rm -f "$tmp"; echo "  Skipped: $dest" ;;
   esac
 }

--- a/install-rules.sh
+++ b/install-rules.sh
@@ -30,40 +30,81 @@ else
   TARGET_DIR="$HOME"
 fi
 
-# prompt_overwrite checks if file exists and prompts user for confirmation.
-# Returns 0 if write should proceed, 1 if skipped.
-prompt_overwrite() {
-  file="$1"
-  if [ ! -f "$file" ]; then
-    return 0
+# checksum computes a SHA-256 hash for a file (portable across Linux and macOS).
+checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f1
   fi
-  if [ "$OVERWRITE_ALL" = "yes" ]; then
-    return 0
-  fi
-  printf "File %s already exists. Overwrite? [y/n/a] " "$file"
-  read -r answer </dev/tty
-  case "$answer" in
-    y|Y) return 0 ;;
-    a|A) OVERWRITE_ALL="yes"; return 0 ;;
-    *)   return 1 ;;
-  esac
 }
 
-# download_file fetches a URL to a local path.
+# file_size returns the size in bytes of a file (portable across Linux and macOS).
+file_size() {
+  wc -c < "$1" | tr -d ' '
+}
+
+# download_file fetches a URL to a local path, comparing checksums when the file already exists.
 download_file() {
   url="$1"
   dest="$2"
   dir="$(dirname "$dest")"
   mkdir -p "$dir"
-  if prompt_overwrite "$dest"; then
-    if curl -fsSL -o "$dest" "$url"; then
-      echo "  Installed: $dest"
-    else
-      echo "  Warning: failed to download $url" >&2
-    fi
-  else
-    echo "  Skipped: $dest"
+
+  # Download to a temporary file first
+  tmp="$(mktemp)"
+  if ! curl -fsSL -o "$tmp" "$url"; then
+    echo "  Warning: failed to download $url" >&2
+    rm -f "$tmp"
+    return
   fi
+
+  # If the local file does not exist, install directly
+  if [ ! -f "$dest" ]; then
+    mv "$tmp" "$dest"
+    echo "  Installed (new): $dest"
+    return
+  fi
+
+  # Compare checksums
+  local_hash="$(checksum "$dest")"
+  remote_hash="$(checksum "$tmp")"
+
+  if [ "$local_hash" = "$remote_hash" ]; then
+    rm -f "$tmp"
+    echo "  Up to date: $dest"
+    return
+  fi
+
+  # Files differ -- show size comparison to help the user decide
+  local_bytes="$(file_size "$dest")"
+  remote_bytes="$(file_size "$tmp")"
+  diff_bytes=$((remote_bytes - local_bytes))
+
+  if [ "$diff_bytes" -gt 0 ]; then
+    size_note="remote is ${diff_bytes} bytes larger (local: ${local_bytes}B, remote: ${remote_bytes}B) -- installing adds content"
+  elif [ "$diff_bytes" -lt 0 ]; then
+    abs_diff=$(( -diff_bytes ))
+    size_note="local is ${abs_diff} bytes larger (local: ${local_bytes}B, remote: ${remote_bytes}B) -- installing removes content"
+  else
+    size_note="same size but different content (${local_bytes}B)"
+  fi
+
+  if [ "$OVERWRITE_ALL" = "yes" ]; then
+    mv "$tmp" "$dest"
+    echo "  Updated: $dest ($size_note)"
+    return
+  fi
+
+  printf "  Changed: %s\n" "$dest"
+  printf "    %s\n" "$size_note"
+  printf "    Overwrite? [y/n/a] "
+  read -r answer </dev/tty
+  case "$answer" in
+    y|Y) mv "$tmp" "$dest"; echo "  Updated: $dest" ;;
+    a|A) OVERWRITE_ALL="yes"; mv "$tmp" "$dest"; echo "  Updated: $dest" ;;
+    *)   rm -f "$tmp"; echo "  Skipped: $dest" ;;
+  esac
 }
 
 # list_remote_entries fetches entry names from a directory on the generated branch via the GitHub API.
@@ -99,6 +140,13 @@ echo ""
 echo "Claude Code agents:"
 for file in $(list_remote_entries "claude/agents"); do
   download_file "${BASE_URL}/claude/agents/${file}" "${TARGET_DIR}/.claude/agents/${file}"
+done
+echo ""
+
+# Claude Code hooks (.claude/hooks/*)
+echo "Claude Code hooks:"
+for file in $(list_remote_entries "claude/hooks"); do
+  download_file "${BASE_URL}/claude/hooks/${file}" "${TARGET_DIR}/.claude/hooks/${file}"
 done
 echo ""
 


### PR DESCRIPTION
## Summary

- Added `fix-ci` slash command as a static asset for auto-detecting failing CI checks, classifying failures, and pushing fixes
- Added `changelog-guard.sh` as the first static hook, blocking commits that add CHANGELOG entries outside the `[Unreleased]` section
- Updated the `generate-ai-rules.yaml` workflow to copy and merge static hooks alongside agents, commands, and skills
- Added hooks installation section to `install-rules.sh`
- Replaced blind file overwrite in `install-rules.sh` with SHA-256 checksum comparison that shows byte-level size differences and warns whether installing adds or removes content

## Test plan

- [ ] Run `bash -n install-rules.sh` to validate syntax
- [ ] Run `cd .github/workflows/generate-ai-rules && go build -o /dev/null ./... && go test ./...` to verify the Go tool still builds and passes
- [ ] Run `bash .github/workflows/sync-docs/check-toc-sync.sh` to confirm TOC sync is unaffected
- [ ] Trigger the `generate-ai-rules` workflow manually and verify `claude/hooks/changelog-guard.sh` and `claude/commands/fix-ci.md` appear on the `generated` branch
- [ ] Run `install-rules.sh` against a test directory and verify checksum comparison output for new, unchanged, and changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)