### PR TITLE
fix(workflows): align Go version with subproject go.mod

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,13 +24,13 @@ Always reference these instructions first and fallback to search or bash command
 ### Core Build Process
 The repository has two Go-based tools under `.github/workflows/`:
 
-#### update-wiki (Go 1.26.0)
+#### update-wiki (Go 1.26.2)
 Syncs documentation to GitHub Wiki:
 - Build location: `.github/workflows/update-wiki/`
 - Build command: `go build -o update-wiki ./...`
 - Expected build time: ~1 second
 
-#### generate-ai-rules (Go 1.24.7)
+#### generate-ai-rules (Go 1.26.2)
 Generates AI assistant rule files for Claude Code, Cursor, Codex, and GitHub Copilot. Also fetches external agents from configured repositories.
 - Build location: `.github/workflows/generate-ai-rules/`
 - Build command: `go build -o generate-ai-rules ./...`
@@ -140,8 +140,8 @@ Use `install-rules.sh` to distribute the generated AI rule files (downloaded fro
 ├── install-rules.sh                  # Script to install AI rules from 'generated' branch
 ├── .editorconfig                     # Formatting standards
 ├── .github/workflows/                # CI/CD automation
-│   ├── update-wiki.yml               # Syncs docs to GitHub Wiki (Go 1.26.0)
-│   ├── generate-ai-rules.yaml        # Generates AI rules on 'generated' branch (Go 1.24.7)
+│   ├── update-wiki.yml               # Syncs docs to GitHub Wiki (Go 1.26.2)
+│   ├── generate-ai-rules.yaml        # Generates AI rules on 'generated' branch (Go 1.26.2)
 │   ├── generate-ai-rules/            # Go tool + static assets
 │   │   ├── agents/                   # Claude Code agent source files (7 static agents)
 │   │   ├── commands/                 # Claude Code command source files (8 commands)
@@ -213,7 +213,7 @@ bash .github/workflows/sync-docs/check-toc-sync.sh
 - **Type**: Documentation repository (not traditional software)
 - **Primary content**: 79+ Markdown files across 25+ directories
 - **Build output**: GitHub Wiki synchronization + AI rule files for Claude Code, Cursor, Codex, and GitHub Copilot (on `generated` branch)
-- **Dependencies**: Go 1.26.0 for update-wiki; Go 1.24.7 for generate-ai-rules (+ gopkg.in/yaml.v3 for external sources)
+- **Dependencies**: Go 1.26.2 for update-wiki and generate-ai-rules (+ `gopkg.in/yaml.v3` for external sources)
 - **Tests**: Both Go modules include test files (`*_test.go`)
 
 ### Navigation File Sync Requirement

--- a/.github/workflows/generate-ai-rules.yaml
+++ b/.github/workflows/generate-ai-rules.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Set Up Go'
         uses: 'actions/setup-go@v6'
         with:
-          go-version: '1.23.4'
+          go-version-file: '${{ env.PROJECT_PATH }}/go.mod'
           cache-dependency-path: '${{ env.PROJECT_PATH }}/go.sum'
 
       - name: 'Build Go Program'

--- a/.github/workflows/generate-ai-rules/go.mod
+++ b/.github/workflows/generate-ai-rules/go.mod
@@ -1,6 +1,6 @@
 module github.com/rios0rios0/guide/generate-ai-rules
 
-go 1.24.7
+go 1.26.2
 
 require (
 	github.com/sirupsen/logrus v1.9.4

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -28,8 +28,8 @@ jobs:
       - name: 'Set Up Go'
         uses: 'actions/setup-go@v6'
         with:
-          go-version: '1.23.4'
-          cache-dependency-path: ${{ env.PROJECT_PATH }}/go.sum
+          go-version-file: '${{ env.PROJECT_PATH }}/go.mod'
+          cache-dependency-path: '${{ env.PROJECT_PATH }}/go.sum'
 
       - name: 'Build Go Program'
         run: |

--- a/.github/workflows/update-wiki/go.mod
+++ b/.github/workflows/update-wiki/go.mod
@@ -1,6 +1,6 @@
 module github.com/rios0rios0/guide
 
-go 1.26.0
+go 1.26.2
 
 require github.com/sirupsen/logrus v1.9.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- bumped `update-wiki` and `generate-ai-rules` Go modules to `1.26.2`
+- switched `update-wiki.yml` and `generate-ai-rules.yaml` workflows to `go-version-file` so the workflow Go version always tracks each subproject's `go.mod`, preventing future drift
+
+### Fixed
+
+- aligned the workflow Go version with each subproject's `go.mod`, fixing the `go: go.mod requires go >= 1.24.7 / 1.26.0` build failures in `Generate AI Rules` and `Update Wiki`
+
 ## [0.3.1] - 2026-04-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- aligned the workflow Go version with each subproject's `go.mod`, fixing the `go: go.mod requires go >= 1.24.7 / 1.26.0` build failures in `Generate AI Rules` and `Update Wiki`
+- aligned the workflow Go version with each subproject's `go.mod`, fixing build failures in `Generate AI Rules` and `Update Wiki` caused by workflow/toolchain version drift
 
 ## [0.3.1] - 2026-04-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,12 @@ A documentation repository that serves as the single source of truth for softwar
 There is no Makefile. The two Go tools are built and tested independently:
 
 ```bash
-# update-wiki tool (Go 1.26.0) — syncs docs to GitHub Wiki
+# update-wiki tool (Go 1.26.2) — syncs docs to GitHub Wiki
 cd .github/workflows/update-wiki
 go build -o update-wiki ./...
 go test ./...
 
-# generate-ai-rules tool (Go 1.24.7) — generates AI rule files from docs
+# generate-ai-rules tool (Go 1.26.2) — generates AI rule files from docs
 cd .github/workflows/generate-ai-rules
 go build -o generate-ai-rules ./...
 go test ./...


### PR DESCRIPTION
## Summary

Fixes the pre-existing `Generate AI Rules` and `Update Wiki` failures that surfaced after the `chore/bump-github-actions` merge. Root cause: the workflows pinned `go-version: '1.23.4'` while the subproject `go.mod` files required newer Go versions. With `GOTOOLCHAIN=local`, Go refused to download a newer toolchain and the build failed.

### Changes

- **`.github/workflows/generate-ai-rules/go.mod`**: bumped `go 1.24.7` → `go 1.26.2`
- **`.github/workflows/update-wiki/go.mod`**: bumped `go 1.26.0` → `go 1.26.2`
- **`.github/workflows/generate-ai-rules.yaml`**: replaced hardcoded `go-version: '1.23.4'` with `go-version-file: '${{ env.PROJECT_PATH }}/go.mod'`
- **`.github/workflows/update-wiki.yml`**: same swap (also quoted the previously-unquoted `cache-dependency-path` per YAML conventions)
- **`CLAUDE.md`** + **`.github/copilot-instructions.md`**: refreshed Go version mentions
- **`CHANGELOG.md`**: added an entry under `[Unreleased]`

### Why `go-version-file` instead of bumping the literal version string?

Hardcoded `go-version` values silently drift whenever someone bumps `go.mod`. Using `go-version-file` makes the workflow self-correcting: change `go.mod`, the workflow follows automatically. Prevents this exact failure mode from recurring.

## Test plan

- [ ] CI runs `Generate AI Rules` and `Update Wiki` successfully on this branch
- [ ] Build step installs Go `1.26.2` (visible in setup-go logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)