### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` to correct the generated rule-file count from 14 to 15 per assistant, matching the 15 rule groups defined in `generate-ai-rules` `config.go`
+
 ## [0.4.0] - 2026-05-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,13 @@ Hand-written files that the workflow copies to the `generated` branch alongside 
 ### Generated Output (on `generated` branch)
 
 The `generated` branch contains the distributable rule files:
-- `claude/rules/` — 14 rule files (`.md`) — auto-generated from docs
+- `claude/rules/` — 15 rule files (`.md`) — auto-generated from docs
 - `claude/commands/` — 8 slash commands — copied from static assets
 - `claude/agents/` — 7 agents — copied from static assets
 - `claude/hooks/` — 1 hook — copied from static assets
-- `cursor/rules/` — 14 rule files (`.mdc`) — auto-generated from docs
+- `cursor/rules/` — 15 rule files (`.mdc`) — auto-generated from docs
 - `cursor/skills/` — 5 skills — copied from static assets
-- `copilot/instructions/` — 14 instruction files (`.instructions.md`) — auto-generated with `applyTo` frontmatter
+- `copilot/instructions/` — 15 instruction files (`.instructions.md`) — auto-generated with `applyTo` frontmatter
 - `codex/` — `AGENTS.md` and `rules/default.rules` — auto-generated
 - `aisync-source.yaml` — source definition for aisync users
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.