### PR TITLE
docs(go-testing): remove mandatory `//go:build unit` tag from unit tests

### DIFF
--- a/.github/workflows/generate-ai-rules/commands/scaffold-go-project.md
+++ b/.github/workflows/generate-ai-rules/commands/scaffold-go-project.md
@@ -239,7 +239,7 @@ func injectController() *controllers.ListUsersController {
 ### 8. Create test structure
 
 - Place test files next to production files with `_test.go` suffix
-- Add build flags: `//go:build unit` or `//go:build integration`
+- Unit tests do not need build tags — Go runs `_test.go` files by default. Add build flags (`//go:build integration`, `//go:build e2e`, etc.) only for tests that require external infrastructure
 - Use `stretchr/testify` suites and `assert`/`require` for assertions
 - Create builders in `test/domain/builders/` for test data
 - Create doubles (stubs/dummies) in `test/domain/doubles/repositories/`

--- a/.github/workflows/generate-ai-rules/skills/scaffold-go-project/SKILL.md
+++ b/.github/workflows/generate-ai-rules/skills/scaffold-go-project/SKILL.md
@@ -244,7 +244,7 @@ func injectController() *controllers.ListUsersController {
 ### 8. Create test structure
 
 - Place test files next to production files with `_test.go` suffix
-- Add build flags: `//go:build unit` or `//go:build integration`
+- Unit tests do not need build tags — Go runs `_test.go` files by default. Add build flags (`//go:build integration`, `//go:build e2e`, etc.) only for tests that require external infrastructure
 - Use `stretchr/testify` suites and `assert`/`require` for assertions
 - Create builders in `test/domain/builders/` for test data
 - Create doubles (stubs/dummies) in `test/domain/doubles/repositories/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- changed Go testing convention to remove mandatory `//go:build unit` tag from unit tests — build tags are now required only for integration, e2e, and other non-unit test types
+
 ## [0.4.1] - 2026-06-03
 
 ### Changed

--- a/Code-Style/GoLang/GoLang-Testing.md
+++ b/Code-Style/GoLang/GoLang-Testing.md
@@ -1,6 +1,6 @@
 # Go Testing Conventions
 
-> **TL;DR:** Use build flags (`//go:build unit` or `//go:build integration`) on every test file. Place test files next to production code with the `_test.go` suffix. Use `stretchr/testify` for suites and assertions. Test packages must be **external** to the production package. All tests must follow the BDD pattern with `// given`, `// when`, `// then` comment blocks. Unit tests must run in **parallel** using `t.Parallel()` + `t.Run()`. Integration tests use **suites** with setup/teardown and are NOT parallel.
+> **TL;DR:** Unit tests need **no build tag** — Go runs `_test.go` files by default, so a tag would be redundant. Use build flags (`//go:build integration`, `//go:build e2e`, etc.) **only** on non-unit test files that require external infrastructure. Place test files next to production code with the `_test.go` suffix. Use `stretchr/testify` for suites and assertions. Test packages must be **external** to the production package. All tests must follow the BDD pattern with `// given`, `// when`, `// then` comment blocks. Unit tests must run in **parallel** using `t.Parallel()` + `t.Run()`. Integration tests use **suites** with setup/teardown and are NOT parallel.
 
 ## Overview
 
@@ -28,13 +28,14 @@ test/
 
 ## General Conventions
 
-1. **Build flags are mandatory.** Every test file must start with a build flag specifying the test type:
-   ```go
-   //go:build unit
-   ```
+1. **Build flags for non-unit tests only.** Unit tests do **not** use build tags — Go discovers and runs `_test.go` files by default, so a `//go:build unit` tag is redundant. Build flags are required only for tests that depend on external infrastructure (databases, APIs, containers, etc.):
    ```go
    //go:build integration
    ```
+   ```go
+   //go:build e2e
+   ```
+   Running `go test ./...` executes only untagged (unit) tests. To include integration tests: `go test -tags=integration ./...`.
 2. **External test packages.** The test package must be outside the production code package. For example, if the production code is in `package commands`, the test file must use `package commands_test`.
 3. **Testing framework.** Use [`stretchr/testify`](https://github.com/stretchr/testify) for test suites and assertions.
 4. **File naming.** Test files use the `_test` suffix (e.g., `sqlx_items_repository_test.go`).


### PR DESCRIPTION
- unit tests no longer require a build tag since Go runs `_test.go` files by default, making the `//go:build unit` tag redundant
- build tags are now required only for non-unit tests (integration, e2e) that depend on external infrastructure
- updated scaffold commands and skills to reflect the new convention

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional change, no new features)
- [x] Documentation update
- [ ] CI/CD or build system change
- [ ] Other (describe below)

## Related Issues

<!-- Link issues this PR resolves. Use "Closes #<number>" to auto-close them on merge. -->
Closes #

## Screenshots / Logs

<!-- If applicable, paste screenshots, terminal output, or benchmark results. -->

## Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/rios0rios0/.github/blob/main/CONTRIBUTING.md) guidelines
- [ ] My branch is rebased on top of `main` (no merge commits)
- [ ] I have updated `CHANGELOG.md` under `[Unreleased]` (if applicable)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have added or updated tests for my changes
- [ ] I have run `make lint` and `make test` locally and they pass
- [ ] I have updated documentation (if applicable)
